### PR TITLE
Document Page Polishing

### DIFF
--- a/backend/app/api/dependencies/database.py
+++ b/backend/app/api/dependencies/database.py
@@ -2,13 +2,13 @@ from collections.abc import AsyncGenerator
 from typing import Annotated
 
 import core.config as cfg
+from core.app_exception import AppException
 from core.config import (
     DATABASE_URL,
     DB_CONNECTION_TIMEOUT,
     DB_STATEMENT_TIMEOUT,
     DEBUG,
 )
-from core.app_exception import AppException
 from core.logger import get_logger
 from fastapi import Depends, HTTPException
 from sqlalchemy import event, text

--- a/backend/app/api/dependencies/events.py
+++ b/backend/app/api/dependencies/events.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import json
 from collections.abc import Callable
+from datetime import datetime
 from typing import Annotated, Any, Literal
 
 import core.config as cfg
@@ -9,9 +10,24 @@ import redis.asyncio as redis
 from core.logger import get_logger
 from fastapi import Request, WebSocket
 from fastapi.params import Depends
+from pydantic import BaseModel
 
 app_logger = get_logger("app")
 events_logger = get_logger("events")
+
+# Heartbeat interval for active user tracking (in seconds)
+HEARTBEAT_INTERVAL = 180  # 3 minutes
+# Key expiry for active users (slightly longer than heartbeat to handle delays)
+USER_KEY_EXPIRY = HEARTBEAT_INTERVAL + 60  # 4 minutes
+
+
+class ConnectedUser(BaseModel):
+    """Represents a user connected to a document."""
+
+    user_id: int
+    username: str
+    connection_id: str
+    connected_at: str
 
 
 class EventManager:
@@ -58,6 +74,67 @@ class EventManager:
         if self._redis:
             await self._redis.aclose()
         app_logger.info("EventManager disconnected")
+
+    # ---------------- Active User Tracking ----------------
+    def _active_users_key(self, document_id: str) -> str:
+        """Get Redis key for active users of a document."""
+        return f"document:{document_id}:active_users"
+
+    async def add_active_user(
+        self, document_id: str, user_id: int, username: str, connection_id: str
+    ) -> list[ConnectedUser]:
+        """Add a user to the active users list and return all active users."""
+        if not self._redis:
+            raise RuntimeError("Redis connection not initialized")
+
+        key = self._active_users_key(document_id)
+        user_data = ConnectedUser(
+            user_id=user_id,
+            username=username,
+            connection_id=connection_id,
+            connected_at=datetime.now().isoformat()
+        )
+
+        # Add user to hash and set expiry
+        await self._redis.hset(key, str(user_id), user_data.model_dump_json())
+        await self._redis.expire(key, USER_KEY_EXPIRY)
+
+        events_logger.info("Added active user %s to document %s", username, document_id)
+        return await self.get_active_users(document_id)
+
+    async def remove_active_user(self, document_id: str, user_id: int) -> None:
+        """Remove a user from the active users list."""
+        if not self._redis:
+            raise RuntimeError("Redis connection not initialized")
+
+        key = self._active_users_key(document_id)
+        await self._redis.hdel(key, str(user_id))
+        events_logger.info("Removed active user %s from document %s", user_id, document_id)
+
+    async def get_active_users(self, document_id: str) -> list[ConnectedUser]:
+        """Get all active users for a document."""
+        if not self._redis:
+            raise RuntimeError("Redis connection not initialized")
+
+        key = self._active_users_key(document_id)
+        users_data = await self._redis.hgetall(key)
+
+        users = []
+        for user_json in users_data.values():
+            try:
+                users.append(ConnectedUser.model_validate_json(user_json))
+            except Exception as e:
+                events_logger.warning("Failed to parse user data: %s", e)
+
+        return users
+
+    async def refresh_user_heartbeat(self, document_id: str) -> None:
+        """Refresh the expiry for active users (called periodically as heartbeat)."""
+        if not self._redis:
+            return
+
+        key = self._active_users_key(document_id)
+        await self._redis.expire(key, USER_KEY_EXPIRY)
 
     # ---------------- WebSocket client management ----------------
     async def register_client(self, websocket: WebSocket, *, channel: str, on_event: Callable[[dict], Any]) -> None:

--- a/backend/app/api/docs/websocket.jinja
+++ b/backend/app/api/docs/websocket.jinja
@@ -49,6 +49,24 @@ Refer to endpoint response schema for reference on event structure.
 <td style='border: 1px solid #ddd; padding: 8px;'>❌ No</td>
 </tr>
 {%- endif %}
+
+{%- if view_mode_model %}
+<tr>
+<td style='border: 1px solid #ddd; padding: 8px;'><code>view_mode_changed</code></td>
+<td style='border: 1px solid #ddd; padding: 8px;'><code>{{ view_mode_model.__name__ }}</code></td>
+<td style='border: 1px solid #ddd; padding: 8px;'><code>{{ view_mode_model.__name__ }}</code></td>
+<td style='border: 1px solid #ddd; padding: 8px;'>❌ No</td>
+</tr>
+{%- endif %}
+
+{%- if mouse_model %}
+<tr>
+<td style='border: 1px solid #ddd; padding: 8px;'><code>mouse_position</code></td>
+<td style='border: 1px solid #ddd; padding: 8px;'><code>{{ mouse_model.__name__ }}</code></td>
+<td style='border: 1px solid #ddd; padding: 8px;'><code>{{ mouse_model.__name__ }}</code></td>
+<td style='border: 1px solid #ddd; padding: 8px;'>❌ No</td>
+</tr>
+{%- endif %}
 </tbody>
 </table>
 </ul>

--- a/backend/app/api/routers/documents.py
+++ b/backend/app/api/routers/documents.py
@@ -10,9 +10,10 @@ from api.dependencies.s3 import S3
 from api.routers.events import (
     EventModelConfig,
     EventRouterConfig,
-    get_events_router,
     can_user_see_comment,
+    get_events_router,
 )
+from core.app_exception import AppException
 from fastapi import (
     BackgroundTasks,
     Body,
@@ -22,9 +23,6 @@ from fastapi import (
     Response,
     UploadFile,
 )
-from sqlmodel import select
-from starlette.responses import StreamingResponse
-from core.app_exception import AppException
 from models.comment import (
     CommentDelete,
     CommentRead,
@@ -35,14 +33,16 @@ from models.document import (
     DocumentRead,
     DocumentTransfer,
     DocumentUpdate,
-    ViewModeChangedEvent,
     MousePositionEvent,
+    ViewModeChangedEvent,
 )
 from models.enums import AppErrorCode, Permission, Visibility
 from models.event import Event
 from models.filter import DocumentFilter
 from models.pagination import Paginated
 from models.tables import Comment, Document, Group, Membership, User
+from sqlmodel import select
+from starlette.responses import StreamingResponse
 from util.api_router import APIRouter
 from util.queries import Guard
 from util.response import ExcludableFieldsJSONResponse

--- a/backend/app/api/routers/events.py
+++ b/backend/app/api/routers/events.py
@@ -262,7 +262,7 @@ def get_events_router[TableModel: SQLModel, RelatedResourceModel: BaseModel, Cre
                 return bool(config.mouse_position and config.mouse_position.model)
             return False
 
-        async def on_event(event_data: dict) -> None: # noqa: C901
+        async def on_event(event_data: dict) -> None:
             """Validate outgoing event before sending to client.
 
             Permission filtering logic for comment events:

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -12,7 +12,7 @@ from models.document import (
     DocumentRead,
     DocumentTransfer,
     MousePositionEvent,
-    ViewModeChangedEvent
+    ViewModeChangedEvent,
 )
 from models.enums import AppErrorCode
 from models.event import CommentEvent, Event

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -11,6 +11,8 @@ from models.document import (
     DocumentCreate,
     DocumentRead,
     DocumentTransfer,
+    MousePositionEvent,
+    ViewModeChangedEvent
 )
 from models.enums import AppErrorCode
 from models.event import CommentEvent, Event
@@ -41,6 +43,9 @@ from models.user import UserCreate, UserPrivate, UserRead, UserUpdate
 # ! Models that use TYPE_CHECKING for string type hints need to be imported and rebuilt here to avoid runtime errors
 
 AppError.model_rebuild()
+
+MousePositionEvent.model_rebuild()
+ViewModeChangedEvent.model_rebuild()
 
 Event.model_rebuild()
 CommentEvent.model_rebuild()

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from sqlmodel import Field, SQLModel
 
 from models.base import BaseModel
-from models.enums import Visibility
+from models.enums import ViewMode, Visibility
 
 if TYPE_CHECKING:
     from models.group import GroupRead
@@ -21,11 +21,30 @@ class DocumentRead(BaseModel):
     name: str
     group_id: str
     visibility: Visibility
-    view_mode: Visibility
+    view_mode: ViewMode
 
 class DocumentTransfer(SQLModel):
     group_id: str
 
 class DocumentUpdate(SQLModel):
     visibility: Visibility | None = None
+    view_mode: ViewMode | None = None
     name: str | None = Field(default=None, max_length=255)
+
+
+class ViewModeChangedEvent(SQLModel):
+    """Event payload for view_mode changes - sent to WebSocket clients."""
+
+    document_id: str
+    view_mode: ViewMode
+
+
+class MousePositionEvent(SQLModel):
+    """Event payload for mouse cursor position - sent to WebSocket clients for real-time cursor tracking."""
+
+    user_id: int
+    username: str
+    x: float  # Normalized X position (0-1 relative to PDF page width)
+    y: float  # Normalized Y position (0-1 relative to PDF page height)
+    page: int  # Page number (1-indexed)
+    visible: bool = True  # False when mouse leaves the PDF area

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -20,7 +20,6 @@ class Permission(str, Enum):
     # Comments
     ADD_COMMENTS = "add_comments"
     REMOVE_COMMENTS = "remove_comments"
-    VIEW_PUBLIC_COMMENTS = "view_public_comments"
     VIEW_RESTRICTED_COMMENTS = "view_restricted_comments"
     
     # Members
@@ -42,10 +41,13 @@ class Permission(str, Enum):
 
 
 class ViewMode(str, Enum):
-    """Document view mode settings."""
+    """Document view mode settings.
 
-    PRIVATE = "private"
-    ANONYMOUS = "anonymous"
+    RESTRICTED: Only owner, admins, and users with VIEW_RESTRICTED_COMMENTS can see comments
+    PUBLIC: Comments visible based on individual comment visibility settings
+    """
+
+    RESTRICTED = "restricted"
     PUBLIC = "public"
 
 

--- a/backend/app/models/event.py
+++ b/backend/app/models/event.py
@@ -19,7 +19,7 @@ class Event[Payload: PydanticBaseModel](PydanticBaseModel):
     payload: Payload | None
     resource_id: int | None
     resource: str | None
-    type: Literal["create", "update", "delete", "custom"]
+    type: Literal["create", "update", "delete", "view_mode_changed", "mouse_position"]
     originating_connection_id: str | None = None  # Connection that triggered this event (to avoid echo)
 
 
@@ -32,7 +32,7 @@ class CommentEvent(PydanticBaseModel):
     payload: "CommentRead | None"
     resource_id: int | None
     resource: str | None
-    type: Literal["create", "update", "delete", "custom"]
+    type: Literal["create", "update", "delete", "view_mode_changed", "mouse_position"]
     originating_connection_id: str | None = None
 
 

--- a/backend/tests/factories/models.py
+++ b/backend/tests/factories/models.py
@@ -35,7 +35,7 @@ class GroupFactory(BaseFactory):
 
     name = factory.Sequence(lambda n: f"Group {n}")
     secret = factory.LazyFunction(lambda: str(uuid4()))
-    default_permissions = factory.LazyFunction(lambda: [Permission.VIEW_PUBLIC_COMMENTS])
+    default_permissions = factory.LazyFunction(lambda: [])
 
 
 class MembershipFactory(BaseFactory):
@@ -44,7 +44,7 @@ class MembershipFactory(BaseFactory):
 
     user = factory.SubFactory(UserFactory)
     group = factory.SubFactory(GroupFactory)
-    permissions = factory.LazyFunction(lambda: [Permission.VIEW_PUBLIC_COMMENTS])
+    permissions = factory.LazyFunction(lambda: [])
     is_owner = False
     accepted = True
 
@@ -88,7 +88,7 @@ class ShareLinkFactory(BaseFactory):
 
     group = factory.SubFactory(GroupFactory)
     created_by = factory.SubFactory(UserFactory)
-    permissions = factory.LazyFunction(lambda: [Permission.VIEW_PUBLIC_COMMENTS])
+    permissions = factory.LazyFunction(lambda: [])
     token = factory.LazyFunction(lambda: str(uuid4()))
     expires_at = factory.LazyFunction(lambda: datetime.now(UTC) + timedelta(days=7))
     label = factory.Faker("sentence")

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -9,9 +9,11 @@ export const reactionTypeSchema = z.union([z.literal("like"), z.literal("dislike
 
 export const visibility1Schema = z.union([z.literal("private"), z.literal("restricted"), z.literal("public")]);
 
-export const viewModeSchema = z.union([z.literal("private"), z.literal("anonymous"), z.literal("public")]);
+export const viewModeSchema = z.union([z.literal("restricted"), z.literal("public")]);
 
-export const permissionSchema = z.union([z.literal("administrator"), z.literal("add_comments"), z.literal("remove_comments"), z.literal("view_public_comments"), z.literal("view_restricted_comments"), z.literal("add_members"), z.literal("remove_members"), z.literal("manage_permissions"), z.literal("upload_documents"), z.literal("view_restricted_documents"), z.literal("delete_documents"), z.literal("remove_reactions"), z.literal("add_reactions"), z.literal("manage_share_links")]);
+export const viewMode1Schema = z.union([z.literal("restricted"), z.literal("public")]);
+
+export const permissionSchema = z.union([z.literal("administrator"), z.literal("add_comments"), z.literal("remove_comments"), z.literal("view_restricted_comments"), z.literal("add_members"), z.literal("remove_members"), z.literal("manage_permissions"), z.literal("upload_documents"), z.literal("view_restricted_documents"), z.literal("delete_documents"), z.literal("remove_reactions"), z.literal("add_reactions"), z.literal("manage_share_links")]);
 
 export const appErrorSchema = z.object({
     status_code: z.number(),
@@ -100,7 +102,7 @@ export const documentReadSchema = z.object({
     name: z.string(),
     group_id: z.string(),
     visibility: visibilitySchema,
-    view_mode: visibilitySchema
+    view_mode: viewMode1Schema
 });
 
 export const documentTransferSchema = z.object({

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -188,6 +188,15 @@ export const membershipReadSchema = z.object({
     accepted: z.boolean()
 });
 
+export const mousePositionEventSchema = z.object({
+    user_id: z.number(),
+    username: z.string(),
+    x: z.number(),
+    y: z.number(),
+    page: z.number(),
+    visible: z.boolean().optional()
+});
+
 export const filterSchema = z.record(z.string(), z.unknown()).and(z.object({
     field: z.string(),
     operator: z.union([z.literal("=="), z.literal(">="), z.literal("<="), z.literal(">"), z.literal("<"), z.literal("ilike"), z.literal("like"), z.literal("exists"), z.literal("!=")]),
@@ -291,6 +300,11 @@ export const userUpdateSchema = z.object({
     last_name: z.string().optional().nullable()
 });
 
+export const viewModeChangedEventSchema = z.object({
+    document_id: z.string(),
+    view_mode: viewMode1Schema
+});
+
 export const commentReadSchema = z.object({
     created_at: z.string().optional(),
     updated_at: z.string().optional(),
@@ -320,6 +334,6 @@ export const commentEventSchema = z.object({
     payload: commentReadSchema.nullable(),
     resource_id: z.number().nullable(),
     resource: z.string().nullable(),
-    type: z.union([z.literal("create"), z.literal("update"), z.literal("delete"), z.literal("custom")]),
+    type: z.union([z.literal("create"), z.literal("update"), z.literal("delete"), z.literal("view_mode_changed"), z.literal("mouse_position")]),
     originating_connection_id: z.string().optional().nullable()
 });

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -107,7 +107,7 @@ export interface CommentEvent {
   payload: CommentRead | null;
   resource_id: number | null;
   resource: string | null;
-  type: "create" | "update" | "delete" | "custom";
+  type: "create" | "update" | "delete" | "view_mode_changed" | "mouse_position";
   originating_connection_id?: string | null;
 }
 export interface CommentRead {
@@ -269,6 +269,17 @@ export interface MembershipRead {
   is_owner: boolean;
   accepted: boolean;
 }
+/**
+ * Event payload for mouse cursor position - sent to WebSocket clients for real-time cursor tracking.
+ */
+export interface MousePositionEvent {
+  user_id: number;
+  username: string;
+  x: number;
+  y: number;
+  page: number;
+  visible?: boolean;
+}
 export interface PaginatedBase {
   data: unknown[];
   total: number;
@@ -373,4 +384,11 @@ export interface UserUpdate {
   email?: string | null;
   first_name?: string | null;
   last_name?: string | null;
+}
+/**
+ * Event payload for view_mode changes - sent to WebSocket clients.
+ */
+export interface ViewModeChangedEvent {
+  document_id: string;
+  view_mode: ViewMode1;
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -35,8 +35,18 @@ export type ReactionType = "like" | "dislike" | "laugh" | "confused" | "fire";
 export type Visibility1 = "private" | "restricted" | "public";
 /**
  * Document view mode settings.
+ *
+ * RESTRICTED: Only owner, admins, and users with VIEW_RESTRICTED_COMMENTS can see comments
+ * PUBLIC: Comments visible based on individual comment visibility settings
  */
-export type ViewMode = "private" | "anonymous" | "public";
+export type ViewMode = "restricted" | "public";
+/**
+ * Document view mode settings.
+ *
+ * RESTRICTED: Only owner, admins, and users with VIEW_RESTRICTED_COMMENTS can see comments
+ * PUBLIC: Comments visible based on individual comment visibility settings
+ */
+export type ViewMode1 = "restricted" | "public";
 /**
  * Available permissions for group members.
  */
@@ -44,7 +54,6 @@ export type Permission =
   | "administrator"
   | "add_comments"
   | "remove_comments"
-  | "view_public_comments"
   | "view_restricted_comments"
   | "add_members"
   | "remove_members"
@@ -176,7 +185,7 @@ export interface DocumentRead {
   name: string;
   group_id: string;
   visibility: Visibility;
-  view_mode: Visibility;
+  view_mode: ViewMode1;
 }
 export interface DocumentTransfer {
   group_id: string;

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -32,7 +32,9 @@ export const handleFetch: HandleFetch = async ({ request, fetch, event }) => {
 		const cookieHeader = [
 			accessToken ? `access_token=${accessToken}` : '',
 			refreshToken ? `refresh_token=${refreshToken}` : ''
-		].filter(Boolean).join('; ');
+		]
+			.filter(Boolean)
+			.join('; ');
 
 		const headers = new Headers(request.headers);
 		headers.set('Cookie', cookieHeader);

--- a/frontend/src/i18n/de/index.ts
+++ b/frontend/src/i18n/de/index.ts
@@ -58,7 +58,6 @@ const de = {
 		administrator: 'Voller Administratorzugriff',
 		add_comments: 'Kommentare hinzufügen',
 		remove_comments: 'Kommentare entfernen',
-		view_public_comments: 'Öffentliche Kommentare anzeigen',
 		view_restricted_comments: 'Eingeschränkte Kommentare anzeigen',
 		add_members: 'Mitglieder hinzufügen',
 		remove_members: 'Mitglieder entfernen',

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -58,7 +58,6 @@ const en = {
 		administrator: 'Full administrative access',
 		add_comments: 'Add comments',
 		remove_comments: 'Remove comments',
-		view_public_comments: 'View public comments',
 		view_restricted_comments: 'View restricted comments',
 		add_members: 'Add members',
 		remove_members: 'Remove members',

--- a/frontend/src/i18n/i18n-types.ts
+++ b/frontend/src/i18n/i18n-types.ts
@@ -210,10 +210,6 @@ type RootTranslation = {
 		 */
 		remove_comments: string
 		/**
-		 * V​i​e​w​ ​p​u​b​l​i​c​ ​c​o​m​m​e​n​t​s
-		 */
-		view_public_comments: string
-		/**
 		 * V​i​e​w​ ​r​e​s​t​r​i​c​t​e​d​ ​c​o​m​m​e​n​t​s
 		 */
 		view_restricted_comments: string
@@ -554,10 +550,6 @@ export type TranslationFunctions = {
 		 * Remove comments
 		 */
 		remove_comments: () => LocalizedString
-		/**
-		 * View public comments
-		 */
-		view_public_comments: () => LocalizedString
 		/**
 		 * View restricted comments
 		 */

--- a/frontend/src/lib/components/infiniteScrollList.svelte
+++ b/frontend/src/lib/components/infiniteScrollList.svelte
@@ -34,7 +34,11 @@
 		{#each scroll.items as item (item)}
 			<li class="mr-1">
 				{#if onSelect}
-					<button type="button" class="block w-full cursor-pointer rounded-sm" onclick={() => onSelect(item)}>
+					<button
+						type="button"
+						class="block w-full cursor-pointer rounded-sm"
+						onclick={() => onSelect(item)}
+					>
 						{@render itemSnippet(item)}
 					</button>
 				{:else}

--- a/frontend/src/lib/components/pdf/ActiveUsers.svelte
+++ b/frontend/src/lib/components/pdf/ActiveUsers.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+	import { documentWebSocket, type ConnectedUser } from '$lib/stores/documentWebSocket';
+	import { documentStore } from '$lib/runes/document.svelte.js';
+	import { sessionStore } from '$lib/runes/session.svelte.js';
+
+	interface Props {
+		isExpanded?: boolean;
+	}
+
+	let { isExpanded = false }: Props = $props();
+
+	// Get active users from store (reactive)
+	let activeUsers: ConnectedUser[] = $state([]);
+
+	// Subscribe to active users store
+	$effect(() => {
+		const unsubscribe = documentWebSocket.activeUsers.subscribe((users) => {
+			activeUsers = users;
+		});
+		return unsubscribe;
+	});
+
+	// Filter out current user for display
+	let otherUsers = $derived(activeUsers.filter((u) => u.user_id !== sessionStore.currentUser?.id));
+
+	// Show more users when expanded
+	let displayLimit = $derived(isExpanded ? 10 : 3);
+
+	// Get initials from username
+	const getInitials = (username: string): string => {
+		return username.slice(0, 2).toUpperCase();
+	};
+
+	// Generate a consistent color based on user ID
+	const getUserColor = (userId: number): string => {
+		const colors = [
+			'bg-blue-500',
+			'bg-green-500',
+			'bg-purple-500',
+			'bg-orange-500',
+			'bg-pink-500',
+			'bg-teal-500',
+			'bg-indigo-500',
+			'bg-rose-500'
+		];
+		return colors[userId % colors.length];
+	};
+
+	const handleUserClick = (userId: number) => {
+		if (documentStore.authorFilter === userId) {
+			// Toggle off if already filtering by this user
+			documentStore.setAuthorFilter(null);
+		} else {
+			documentStore.setAuthorFilter(userId);
+		}
+	};
+
+	const isFiltered = (userId: number) => documentStore.authorFilter === userId;
+</script>
+
+{#if otherUsers.length > 0}
+	<div class="flex {isExpanded ? 'w-full flex-col' : 'flex-col items-center'} gap-1">
+		{#if isExpanded}
+			<span class="px-1 text-[10px] text-text/40">Active Users</span>
+		{/if}
+
+		{#each otherUsers.slice(0, displayLimit) as user (user.user_id)}
+			<button
+				class="flex items-center gap-2 rounded p-1 transition-colors hover:bg-text/10 {isFiltered(
+					user.user_id
+				)
+					? 'ring-2 ring-primary ring-offset-1 ring-offset-background'
+					: ''}"
+				onclick={() => handleUserClick(user.user_id)}
+				title="{user.username} - Click to filter comments"
+			>
+				<div
+					class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[10px] font-medium text-white {getUserColor(
+						user.user_id
+					)}"
+				>
+					{getInitials(user.username)}
+				</div>
+				{#if isExpanded}
+					<span class="truncate text-xs text-text/70">{user.username}</span>
+				{/if}
+			</button>
+		{/each}
+
+		<!-- Show count if more than display limit -->
+		{#if otherUsers.length > displayLimit}
+			<div
+				class="flex {isExpanded
+					? 'items-center gap-2 p-1'
+					: ''} h-7 w-7 items-center justify-center rounded-full bg-text/30 text-[10px] font-medium text-text"
+				title="{otherUsers.length - displayLimit} more users viewing"
+			>
+				{#if isExpanded}
+					<span>+{otherUsers.length - displayLimit} more</span>
+				{:else}
+					+{otherUsers.length - displayLimit}
+				{/if}
+			</div>
+		{/if}
+	</div>
+{:else if isExpanded}
+	<span class="px-1 text-[10px] text-text/40">No other users viewing</span>
+{/if}

--- a/frontend/src/lib/components/pdf/CommentBadge.svelte
+++ b/frontend/src/lib/components/pdf/CommentBadge.svelte
@@ -35,8 +35,15 @@
 		return selectedIndex;
 	});
 
-	// Show expanded card when badge is hovered, highlight is hovered, or comment is pinned
-	let showCard = $derived(isHovered || !!hoveredCommentInGroup || !!pinnedCommentInGroup);
+	// Check if any comment in this group has active input (editing or replying)
+	let hasActiveInputInGroup = $derived(
+		comments.some((c) => c.isEditing || documentStore.replyingToCommentId === c.id)
+	);
+
+	// Show expanded card when badge is hovered, highlight is hovered, comment is pinned, or input is active
+	let showCard = $derived(
+		isHovered || !!hoveredCommentInGroup || !!pinnedCommentInGroup || hasActiveInputInGroup
+	);
 
 	// Handle mouse enter - set store state
 	const handleMouseEnter = () => {
@@ -55,13 +62,19 @@
 		}
 	};
 
-	// Clear selected comment when card closes (but not if pinned)
+	// Clear selected comment when card closes (but not if pinned or input active)
 	const handleMouseLeave = () => {
 		isHovered = false;
 		documentStore.setBadgeHovered(null);
 		// Small delay to allow for moving to another badge
 		setTimeout(() => {
-			if (!isHovered && !hoveredCommentInGroup && !pinnedCommentInGroup) {
+			// Don't auto-close if there's an active input (editing or replying)
+			if (
+				!isHovered &&
+				!hoveredCommentInGroup &&
+				!pinnedCommentInGroup &&
+				!documentStore.hasActiveInput
+			) {
 				documentStore.setSelected(null);
 				documentStore.setCommentCardActive(false);
 			}

--- a/frontend/src/lib/components/pdf/CommentCard.svelte
+++ b/frontend/src/lib/components/pdf/CommentCard.svelte
@@ -71,11 +71,13 @@
 	let hasUnloadedReplies = $derived(
 		activeComment?.num_replies > 0 && (!activeComment.replies || activeComment.replies.length === 0)
 	);
-	let canModifyComment = $derived(sessionStore.canModifyComment(activeComment?.user?.id ?? null));
+	let canModifyComment = $derived(sessionStore.currentUserId === activeComment?.user?.id);
+	let canDeleteComment = $derived.by(() => {
+		if (sessionStore.currentUserId === activeComment.user?.id) return true;
+		return sessionStore.validatePermissions(['remove_comments']);
+	});
 	let canReply = $derived(
-		sessionStore.currentMembership
-			? sessionStore.validatePermissions(sessionStore.currentMembership, ['add_comments'])
-			: false
+		sessionStore.currentMembership ? sessionStore.validatePermissions(['add_comments']) : false
 	);
 	let hasReplies = $derived(activeComment.replies && activeComment.replies.length > 0);
 
@@ -209,7 +211,7 @@
 <!-- Wrapper: card for top-level, border-left for nested -->
 <div
 	class={isTopLevel
-		? 'comment-card w-full rounded-lg border border-text/10 bg-background shadow-lg shadow-black/20'
+		? 'comment-card border-text/10 bg-background w-full rounded-lg border shadow-lg shadow-black/20'
 		: `border-l-2 ${borderColor} pl-2.5`}
 	role={isTopLevel ? 'button' : undefined}
 	onclick={isTopLevel ? handleCardActivate : undefined}
@@ -218,7 +220,7 @@
 	<!-- Header -->
 	{#if isTopLevel}
 		{#if hasMultiple && comments}
-			<div class="flex gap-1 border-b border-text/10 px-2 pt-2">
+			<div class="border-text/10 flex gap-1 border-b px-2 pt-2">
 				{#each comments as c, idx (c.id)}
 					<button
 						class="rounded-t px-2 py-1.5 text-xs font-medium transition-colors {activeIndex === idx
@@ -230,8 +232,8 @@
 				{/each}
 			</div>
 		{:else}
-			<div class="border-b border-text/10 px-3 py-2">
-				<span class="text-sm font-semibold text-text"
+			<div class="border-text/10 border-b px-3 py-2">
+				<span class="text-text text-sm font-semibold"
 					>{activeComment.user?.username ?? 'Anonymous'}</span
 				>
 			</div>
@@ -244,10 +246,10 @@
 		{#if !isTopLevel}
 			<div class="flex items-center justify-between">
 				<div class="flex items-center gap-2">
-					<span class="text-xs font-medium text-text/70"
+					<span class="text-text/70 text-xs font-medium"
 						>{activeComment.user?.username ?? 'Anonymous'}</span
 					>
-					<span class="text-xs text-text/40">{formatDate(activeComment.created_at)}</span>
+					<span class="text-text/40 text-xs">{formatDate(activeComment.created_at)}</span>
 					{#if canModifyComment && activeComment.visibility}
 						<CommentVisibility
 							commentId={activeComment.id}
@@ -260,7 +262,7 @@
 					<div class="flex items-center gap-1">
 						{#if !isEditing}
 							<button
-								class="rounded p-0.5 text-text/40 transition-colors hover:bg-text/10 hover:text-text/70"
+								class="text-text/40 hover:bg-text/10 hover:text-text/70 rounded p-0.5 transition-colors"
 								onclick={(e) => {
 									e.stopPropagation();
 									documentStore.setEditing(activeComment.id);
@@ -285,15 +287,15 @@
 
 		<!-- Annotation quote (top-level only) -->
 		{#if annotationText}
-			<div class="mb-3 border-l-2 border-primary/50 bg-primary/5 py-1.5 pr-2 pl-2.5">
-				<p class="line-clamp-2 text-xs text-text/60 italic">"{annotationText}"</p>
+			<div class="border-primary/50 bg-primary/5 mb-3 border-l-2 py-1.5 pl-2.5 pr-2">
+				<p class="text-text/60 line-clamp-2 text-xs italic">"{annotationText}"</p>
 			</div>
 		{/if}
 
 		<!-- Top-level meta row (date + controls) -->
 		{#if isTopLevel}
 			<div class="mb-2 flex items-center justify-between">
-				<div class="flex items-center gap-2 text-xs text-text/40">
+				<div class="text-text/40 flex items-center gap-2 text-xs">
 					<span>{formatDate(activeComment.created_at)}</span>
 					{#if wasEdited}<span
 							class="italic"
@@ -307,11 +309,11 @@
 						/>
 					{/if}
 				</div>
-				{#if canModifyComment}
+				{#if canDeleteComment || canModifyComment}
 					<div class="flex items-center gap-1">
-						{#if !isEditing}
+						{#if !isEditing && canModifyComment}
 							<button
-								class="rounded p-1 text-text/40 transition-colors hover:bg-text/10 hover:text-text/70"
+								class="text-text/40 hover:bg-text/10 hover:text-text/70 rounded p-1 transition-colors"
 								onclick={(e) => {
 									e.stopPropagation();
 									documentStore.setEditing(activeComment.id);
@@ -321,13 +323,15 @@
 								<EditIcon class="h-3.5 w-3.5" />
 							</button>
 						{/if}
-						<DeleteConfirmation
-							isOpen={showDeleteConfirm}
-							disabled={isSubmitting}
-							onConfirm={handleDeleteConfirm}
-							onOpen={() => (showDeleteConfirm = true)}
-							onClose={() => (showDeleteConfirm = false)}
-						/>
+						{#if canDeleteComment}
+							<DeleteConfirmation
+								isOpen={showDeleteConfirm}
+								disabled={isSubmitting}
+								onConfirm={handleDeleteConfirm}
+								onOpen={() => (showDeleteConfirm = true)}
+								onClose={() => (showDeleteConfirm = false)}
+							/>
+						{/if}
 					</div>
 				{/if}
 			</div>
@@ -347,7 +351,7 @@
 				/>
 				<div class="{sizes.mt} flex justify-end {sizes.gap}">
 					<button
-						class="flex items-center gap-1 rounded {sizes.buttonPx} text-xs text-text/50 transition-colors hover:bg-text/10 hover:text-text/70"
+						class="flex items-center gap-1 rounded {sizes.buttonPx} text-text/50 hover:bg-text/10 hover:text-text/70 text-xs transition-colors"
 						onclick={(e) => {
 							e.stopPropagation();
 							documentStore.setEditing(null);
@@ -357,7 +361,7 @@
 						<CloseIcon class={sizes.icon} /> Cancel
 					</button>
 					<button
-						class="flex items-center gap-1 rounded bg-primary/20 {sizes.buttonPx} text-xs font-medium text-primary transition-colors hover:bg-primary/30 disabled:opacity-50"
+						class="bg-primary/20 flex items-center gap-1 rounded {sizes.buttonPx} text-primary hover:bg-primary/30 text-xs font-medium transition-colors disabled:opacity-50"
 						onclick={(e) => {
 							e.stopPropagation();
 							handleEdit();
@@ -374,7 +378,7 @@
 				{activeComment.content}
 			</p>
 		{:else if isTopLevel}
-			<p class="mb-3 text-sm text-text/40 italic">No comment text</p>
+			<p class="text-text/40 mb-3 text-sm italic">No comment text</p>
 		{/if}
 
 		<!-- Reply input -->
@@ -391,7 +395,7 @@
 				/>
 				<div class="{sizes.mt} flex justify-end {sizes.gap}">
 					<button
-						class="rounded {sizes.buttonPx} text-xs text-text/50 transition-colors hover:bg-text/10 hover:text-text/70"
+						class="rounded {sizes.buttonPx} text-text/50 hover:bg-text/10 hover:text-text/70 text-xs transition-colors"
 						onclick={(e) => {
 							e.stopPropagation();
 							showReplyInput = false;
@@ -399,7 +403,7 @@
 						}}>Cancel</button
 					>
 					<button
-						class="rounded bg-primary/20 {sizes.buttonPx} text-xs font-medium text-primary transition-colors hover:bg-primary/30 disabled:opacity-50"
+						class="bg-primary/20 rounded {sizes.buttonPx} text-primary hover:bg-primary/30 text-xs font-medium transition-colors disabled:opacity-50"
 						onclick={(e) => {
 							e.stopPropagation();
 							handleReply();
@@ -427,7 +431,7 @@
 		<!-- Load replies button -->
 		{#if hasUnloadedReplies}
 			<button
-				class="mt-1.5 flex items-center {sizes.gap} text-xs text-text/60 transition-colors hover:text-text/70"
+				class="mt-1.5 flex items-center {sizes.gap} text-text/60 hover:text-text/70 text-xs transition-colors"
 				onclick={(e) => {
 					e.stopPropagation();
 					handleLoadReplies();
@@ -443,12 +447,12 @@
 
 		<!-- Replies -->
 		{#if hasReplies}
-			<div class={isTopLevel ? 'border-t border-text/10 pt-2' : 'mt-2'}>
+			<div class={isTopLevel ? 'border-text/10 border-t pt-2' : 'mt-2'}>
 				<button
 					class="{isTopLevel
 						? 'mb-2 w-full'
 						: 'mb-1.5'} flex items-center gap-0.5 text-xs {isTopLevel
-						? 'font-medium text-text/50 hover:text-text/70'
+						? 'text-text/50 hover:text-text/70 font-medium'
 						: 'text-text/40 hover:text-text/60'} transition-colors"
 					onclick={(e) => {
 						e.stopPropagation();

--- a/frontend/src/lib/components/pdf/CommentCard.svelte
+++ b/frontend/src/lib/components/pdf/CommentCard.svelte
@@ -3,6 +3,7 @@
 	import { sessionStore } from '$lib/runes/session.svelte.js';
 	import { parseAnnotation } from '$types/pdf';
 	import CommentCard from './CommentCard.svelte';
+	import CommentVisibility from './CommentVisibility.svelte';
 	import DeleteConfirmation from './DeleteConfirmation.svelte';
 	import MarkdownTextEditor from './MarkdownTextEditor.svelte';
 	import ReplyIcon from '~icons/material-symbols/reply';
@@ -71,6 +72,11 @@
 		activeComment?.num_replies > 0 && (!activeComment.replies || activeComment.replies.length === 0)
 	);
 	let canModifyComment = $derived(sessionStore.canModifyComment(activeComment?.user?.id ?? null));
+	let canReply = $derived(
+		sessionStore.currentMembership
+			? sessionStore.validatePermissions(sessionStore.currentMembership, ['add_comments'])
+			: false
+	);
 	let hasReplies = $derived(activeComment.replies && activeComment.replies.length > 0);
 
 	let annotationText = $derived.by(() => {
@@ -89,6 +95,15 @@
 		showReplyInput = false;
 		replyContent = '';
 		showDeleteConfirm = false;
+	});
+
+	// Sync showReplyInput with store for auto-close prevention
+	$effect(() => {
+		if (showReplyInput && activeComment?.id) {
+			documentStore.setReplyingTo(activeComment.id);
+		} else if (!showReplyInput && documentStore.replyingToCommentId === activeComment?.id) {
+			documentStore.setReplyingTo(null);
+		}
 	});
 
 	// Handlers
@@ -233,16 +248,37 @@
 						>{activeComment.user?.username ?? 'Anonymous'}</span
 					>
 					<span class="text-xs text-text/40">{formatDate(activeComment.created_at)}</span>
+					{#if canModifyComment && activeComment.visibility}
+						<CommentVisibility
+							commentId={activeComment.id}
+							visibility={activeComment.visibility}
+							size="sm"
+						/>
+					{/if}
 				</div>
 				{#if canModifyComment}
-					<DeleteConfirmation
-						isOpen={showDeleteConfirm}
-						disabled={isSubmitting}
-						size="sm"
-						onConfirm={handleDeleteConfirm}
-						onOpen={() => (showDeleteConfirm = true)}
-						onClose={() => (showDeleteConfirm = false)}
-					/>
+					<div class="flex items-center gap-1">
+						{#if !isEditing}
+							<button
+								class="rounded p-0.5 text-text/40 transition-colors hover:bg-text/10 hover:text-text/70"
+								onclick={(e) => {
+									e.stopPropagation();
+									documentStore.setEditing(activeComment.id);
+								}}
+								title="Edit"
+							>
+								<EditIcon class="h-3 w-3" />
+							</button>
+						{/if}
+						<DeleteConfirmation
+							isOpen={showDeleteConfirm}
+							disabled={isSubmitting}
+							size="sm"
+							onConfirm={handleDeleteConfirm}
+							onOpen={() => (showDeleteConfirm = true)}
+							onClose={() => (showDeleteConfirm = false)}
+						/>
+					</div>
 				{/if}
 			</div>
 		{/if}
@@ -263,6 +299,13 @@
 							class="italic"
 							title="Last Edit: {formatDate(activeComment.updated_at)}">(edited)</span
 						>{/if}
+					{#if canModifyComment && activeComment.visibility}
+						<CommentVisibility
+							commentId={activeComment.id}
+							visibility={activeComment.visibility}
+							size="md"
+						/>
+					{/if}
 				</div>
 				{#if canModifyComment}
 					<div class="flex items-center gap-1">
@@ -367,7 +410,7 @@
 					</button>
 				</div>
 			</div>
-		{:else}
+		{:else if canReply}
 			<button
 				class="{isTopLevel ? 'mb-3' : 'mt-1'} flex items-center {sizes.gap} text-xs {isTopLevel
 					? 'text-primary hover:text-primary/80'

--- a/frontend/src/lib/components/pdf/CommentCard.svelte
+++ b/frontend/src/lib/components/pdf/CommentCard.svelte
@@ -211,7 +211,7 @@
 <!-- Wrapper: card for top-level, border-left for nested -->
 <div
 	class={isTopLevel
-		? 'comment-card border-text/10 bg-background w-full rounded-lg border shadow-lg shadow-black/20'
+		? 'comment-card w-full rounded-lg border border-text/10 bg-background shadow-lg shadow-black/20'
 		: `border-l-2 ${borderColor} pl-2.5`}
 	role={isTopLevel ? 'button' : undefined}
 	onclick={isTopLevel ? handleCardActivate : undefined}
@@ -220,7 +220,7 @@
 	<!-- Header -->
 	{#if isTopLevel}
 		{#if hasMultiple && comments}
-			<div class="border-text/10 flex gap-1 border-b px-2 pt-2">
+			<div class="flex gap-1 border-b border-text/10 px-2 pt-2">
 				{#each comments as c, idx (c.id)}
 					<button
 						class="rounded-t px-2 py-1.5 text-xs font-medium transition-colors {activeIndex === idx
@@ -232,8 +232,8 @@
 				{/each}
 			</div>
 		{:else}
-			<div class="border-text/10 border-b px-3 py-2">
-				<span class="text-text text-sm font-semibold"
+			<div class="border-b border-text/10 px-3 py-2">
+				<span class="text-sm font-semibold text-text"
 					>{activeComment.user?.username ?? 'Anonymous'}</span
 				>
 			</div>
@@ -246,10 +246,10 @@
 		{#if !isTopLevel}
 			<div class="flex items-center justify-between">
 				<div class="flex items-center gap-2">
-					<span class="text-text/70 text-xs font-medium"
+					<span class="text-xs font-medium text-text/70"
 						>{activeComment.user?.username ?? 'Anonymous'}</span
 					>
-					<span class="text-text/40 text-xs">{formatDate(activeComment.created_at)}</span>
+					<span class="text-xs text-text/40">{formatDate(activeComment.created_at)}</span>
 					{#if canModifyComment && activeComment.visibility}
 						<CommentVisibility
 							commentId={activeComment.id}
@@ -262,7 +262,7 @@
 					<div class="flex items-center gap-1">
 						{#if !isEditing}
 							<button
-								class="text-text/40 hover:bg-text/10 hover:text-text/70 rounded p-0.5 transition-colors"
+								class="rounded p-0.5 text-text/40 transition-colors hover:bg-text/10 hover:text-text/70"
 								onclick={(e) => {
 									e.stopPropagation();
 									documentStore.setEditing(activeComment.id);
@@ -287,15 +287,15 @@
 
 		<!-- Annotation quote (top-level only) -->
 		{#if annotationText}
-			<div class="border-primary/50 bg-primary/5 mb-3 border-l-2 py-1.5 pl-2.5 pr-2">
-				<p class="text-text/60 line-clamp-2 text-xs italic">"{annotationText}"</p>
+			<div class="mb-3 border-l-2 border-primary/50 bg-primary/5 py-1.5 pr-2 pl-2.5">
+				<p class="line-clamp-2 text-xs text-text/60 italic">"{annotationText}"</p>
 			</div>
 		{/if}
 
 		<!-- Top-level meta row (date + controls) -->
 		{#if isTopLevel}
 			<div class="mb-2 flex items-center justify-between">
-				<div class="text-text/40 flex items-center gap-2 text-xs">
+				<div class="flex items-center gap-2 text-xs text-text/40">
 					<span>{formatDate(activeComment.created_at)}</span>
 					{#if wasEdited}<span
 							class="italic"
@@ -313,7 +313,7 @@
 					<div class="flex items-center gap-1">
 						{#if !isEditing && canModifyComment}
 							<button
-								class="text-text/40 hover:bg-text/10 hover:text-text/70 rounded p-1 transition-colors"
+								class="rounded p-1 text-text/40 transition-colors hover:bg-text/10 hover:text-text/70"
 								onclick={(e) => {
 									e.stopPropagation();
 									documentStore.setEditing(activeComment.id);
@@ -351,7 +351,7 @@
 				/>
 				<div class="{sizes.mt} flex justify-end {sizes.gap}">
 					<button
-						class="flex items-center gap-1 rounded {sizes.buttonPx} text-text/50 hover:bg-text/10 hover:text-text/70 text-xs transition-colors"
+						class="flex items-center gap-1 rounded {sizes.buttonPx} text-xs text-text/50 transition-colors hover:bg-text/10 hover:text-text/70"
 						onclick={(e) => {
 							e.stopPropagation();
 							documentStore.setEditing(null);
@@ -361,7 +361,7 @@
 						<CloseIcon class={sizes.icon} /> Cancel
 					</button>
 					<button
-						class="bg-primary/20 flex items-center gap-1 rounded {sizes.buttonPx} text-primary hover:bg-primary/30 text-xs font-medium transition-colors disabled:opacity-50"
+						class="flex items-center gap-1 rounded bg-primary/20 {sizes.buttonPx} text-xs font-medium text-primary transition-colors hover:bg-primary/30 disabled:opacity-50"
 						onclick={(e) => {
 							e.stopPropagation();
 							handleEdit();
@@ -378,7 +378,7 @@
 				{activeComment.content}
 			</p>
 		{:else if isTopLevel}
-			<p class="text-text/40 mb-3 text-sm italic">No comment text</p>
+			<p class="mb-3 text-sm text-text/40 italic">No comment text</p>
 		{/if}
 
 		<!-- Reply input -->
@@ -395,7 +395,7 @@
 				/>
 				<div class="{sizes.mt} flex justify-end {sizes.gap}">
 					<button
-						class="rounded {sizes.buttonPx} text-text/50 hover:bg-text/10 hover:text-text/70 text-xs transition-colors"
+						class="rounded {sizes.buttonPx} text-xs text-text/50 transition-colors hover:bg-text/10 hover:text-text/70"
 						onclick={(e) => {
 							e.stopPropagation();
 							showReplyInput = false;
@@ -403,7 +403,7 @@
 						}}>Cancel</button
 					>
 					<button
-						class="bg-primary/20 rounded {sizes.buttonPx} text-primary hover:bg-primary/30 text-xs font-medium transition-colors disabled:opacity-50"
+						class="rounded bg-primary/20 {sizes.buttonPx} text-xs font-medium text-primary transition-colors hover:bg-primary/30 disabled:opacity-50"
 						onclick={(e) => {
 							e.stopPropagation();
 							handleReply();
@@ -431,7 +431,7 @@
 		<!-- Load replies button -->
 		{#if hasUnloadedReplies}
 			<button
-				class="mt-1.5 flex items-center {sizes.gap} text-text/60 hover:text-text/70 text-xs transition-colors"
+				class="mt-1.5 flex items-center {sizes.gap} text-xs text-text/60 transition-colors hover:text-text/70"
 				onclick={(e) => {
 					e.stopPropagation();
 					handleLoadReplies();
@@ -447,12 +447,12 @@
 
 		<!-- Replies -->
 		{#if hasReplies}
-			<div class={isTopLevel ? 'border-text/10 border-t pt-2' : 'mt-2'}>
+			<div class={isTopLevel ? 'border-t border-text/10 pt-2' : 'mt-2'}>
 				<button
 					class="{isTopLevel
 						? 'mb-2 w-full'
 						: 'mb-1.5'} flex items-center gap-0.5 text-xs {isTopLevel
-						? 'text-text/50 hover:text-text/70 font-medium'
+						? 'font-medium text-text/50 hover:text-text/70'
 						: 'text-text/40 hover:text-text/60'} transition-colors"
 					onclick={(e) => {
 						e.stopPropagation();

--- a/frontend/src/lib/components/pdf/CommentSidebar.svelte
+++ b/frontend/src/lib/components/pdf/CommentSidebar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { documentStore, type CachedComment } from '$lib/runes/document.svelte.js';
+	import { sessionStore } from '$lib/runes/session.svelte.js';
 	import { parseAnnotation, type Annotation } from '$types/pdf';
 	import CommentBadge from './CommentBadge.svelte';
 	import { onMount } from 'svelte';
@@ -21,9 +22,26 @@
 		parsedAnnotation: Annotation;
 	}
 
+	// Apply local filters to comments
+	let filteredComments = $derived.by(() => {
+		let result = documentStore.comments;
+
+		// Filter by specific author
+		if (documentStore.authorFilter !== null) {
+			result = result.filter((c: CachedComment) => c.user?.id === documentStore.authorFilter);
+		}
+
+		// Filter to show only current user's comments
+		if (documentStore.showOnlyMyComments && sessionStore.currentUser) {
+			result = result.filter((c: CachedComment) => c.user?.id === sessionStore.currentUser?.id);
+		}
+
+		return result;
+	});
+
 	// Get comments with valid annotations
 	let commentsWithAnnotations = $derived(
-		documentStore.comments
+		filteredComments
 			.map((c) => ({ ...c, parsedAnnotation: parseAnnotation(c.annotation) }))
 			.filter((c): c is CommentWithAnnotation => c.parsedAnnotation !== null)
 	);

--- a/frontend/src/lib/components/pdf/CommentVisibility.svelte
+++ b/frontend/src/lib/components/pdf/CommentVisibility.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+	import type { Visibility } from '$api/types';
+	import { documentStore } from '$lib/runes/document.svelte.js';
+	import LockIcon from '~icons/material-symbols/lock';
+	import GroupIcon from '~icons/material-symbols/group';
+	import PublicIcon from '~icons/material-symbols/public';
+
+	interface Props {
+		commentId: number;
+		visibility: Visibility;
+		size?: 'sm' | 'md';
+	}
+
+	let { commentId, visibility, size = 'md' }: Props = $props();
+
+	let isOpen = $state(false);
+	let isUpdating = $state(false);
+
+	const visibilityLabels: Record<Visibility, string> = {
+		private: 'Private - Only you',
+		restricted: 'Restricted - Authorized users',
+		public: 'Public - Everyone'
+	};
+
+	const iconSize = $derived(size === 'sm' ? 'h-3 w-3' : 'h-3.5 w-3.5');
+
+	const handleSelect = async (newVisibility: Visibility) => {
+		if (newVisibility === visibility || isUpdating) return;
+		isUpdating = true;
+		isOpen = false;
+
+		try {
+			await documentStore.updateComment(commentId, { visibility: newVisibility });
+		} finally {
+			isUpdating = false;
+		}
+	};
+
+	const handleClickOutside = (e: MouseEvent) => {
+		const target = e.target as HTMLElement;
+		if (!target.closest('.visibility-selector')) {
+			isOpen = false;
+		}
+	};
+
+	$effect(() => {
+		if (isOpen) {
+			document.addEventListener('click', handleClickOutside);
+			return () => document.removeEventListener('click', handleClickOutside);
+		}
+	});
+</script>
+
+<div class="visibility-selector relative">
+	<button
+		class="flex items-center gap-1 rounded px-1 py-0.5 text-text/40 transition-colors hover:bg-text/10 hover:text-text/60 disabled:opacity-50"
+		onclick={(e) => {
+			e.stopPropagation();
+			isOpen = !isOpen;
+		}}
+		disabled={isUpdating}
+		title={visibilityLabels[visibility]}
+	>
+		{#if visibility === 'private'}
+			<LockIcon class={iconSize} />
+		{:else if visibility === 'restricted'}
+			<GroupIcon class={iconSize} />
+		{:else}
+			<PublicIcon class={iconSize} />
+		{/if}
+	</button>
+
+	{#if isOpen}
+		<div
+			class="absolute top-full left-0 z-50 mt-1 min-w-36 rounded-lg border border-text/10 bg-background py-1 shadow-lg"
+		>
+			<button
+				class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors hover:bg-text/5 {visibility ===
+				'private'
+					? 'text-primary'
+					: 'text-text/70'}"
+				onclick={(e) => {
+					e.stopPropagation();
+					handleSelect('private');
+				}}
+			>
+				<LockIcon class="h-3.5 w-3.5" />
+				<span>Private - Only you</span>
+			</button>
+			<button
+				class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors hover:bg-text/5 {visibility ===
+				'restricted'
+					? 'text-primary'
+					: 'text-text/70'}"
+				onclick={(e) => {
+					e.stopPropagation();
+					handleSelect('restricted');
+				}}
+			>
+				<GroupIcon class="h-3.5 w-3.5" />
+				<span>Restricted - Authorized users</span>
+			</button>
+			<button
+				class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors hover:bg-text/5 {visibility ===
+				'public'
+					? 'text-primary'
+					: 'text-text/70'}"
+				onclick={(e) => {
+					e.stopPropagation();
+					handleSelect('public');
+				}}
+			>
+				<PublicIcon class="h-3.5 w-3.5" />
+				<span>Public - Everyone</span>
+			</button>
+		</div>
+	{/if}
+</div>

--- a/frontend/src/lib/components/pdf/Pdf.svelte
+++ b/frontend/src/lib/components/pdf/Pdf.svelte
@@ -7,6 +7,7 @@
 	import CommentSidebar from './CommentSidebar.svelte';
 	import PdfControls from './PdfControls.svelte';
 	import ConnectionLine from './ConnectionLine.svelte';
+	import UserCursors from './UserCursors.svelte';
 	import { documentStore } from '$lib/runes/document.svelte.js';
 	import { PDF_ZOOM_STEP, PDF_MIN_SCALE } from './constants';
 
@@ -229,6 +230,9 @@
 
 		<!-- Text selection handler for creating new annotations -->
 		<TextSelectionHandler viewerContainer={container} />
+
+		<!-- Other users' cursors -->
+		<UserCursors viewerContainer={container} {scale} />
 	</div>
 
 	<!-- Right Sidebar - Comments (expands to fill remaining space) -->

--- a/frontend/src/lib/components/pdf/PdfControls.svelte
+++ b/frontend/src/lib/components/pdf/PdfControls.svelte
@@ -4,6 +4,12 @@
 	import FitPageIcon from '~icons/material-symbols/fit-page';
 	import ChevronUpIcon from '~icons/material-symbols/keyboard-arrow-up';
 	import ChevronDownIcon from '~icons/material-symbols/keyboard-arrow-down';
+	import ExpandIcon from '~icons/material-symbols/chevron-right';
+	import CollapseIcon from '~icons/material-symbols/chevron-left';
+	import PersonIcon from '~icons/material-symbols/person';
+	import ViewModeSelector from './ViewModeSelector.svelte';
+	import ActiveUsers from './ActiveUsers.svelte';
+	import { documentStore } from '$lib/runes/document.svelte.js';
 
 	interface Props {
 		scale: number;
@@ -30,55 +36,136 @@
 		onPrevPage,
 		onNextPage
 	}: Props = $props();
+
+	let isExpanded = $state(false);
+
+	const buttonClass =
+		'rounded p-2 text-text/70 transition-colors hover:bg-text/10 hover:text-text disabled:opacity-30 disabled:hover:bg-transparent';
+	const activeButtonClass =
+		'rounded p-2 text-primary bg-primary/10 transition-colors hover:bg-primary/20';
 </script>
 
-<div class="flex w-12 shrink-0 flex-col items-center gap-1 border-r border-text/10 bg-inset py-3">
-	<!-- Zoom Controls -->
+<div
+	class="flex shrink-0 flex-col border-r border-text/10 bg-inset transition-all duration-200 {isExpanded
+		? 'w-40'
+		: 'w-12'}"
+>
+	<!-- Expand/Collapse Button -->
 	<button
-		class="rounded p-2 text-text/70 transition-colors hover:bg-text/10 hover:text-text disabled:opacity-30 disabled:hover:bg-transparent"
-		onclick={onZoomIn}
-		disabled={scale >= maxScale}
-		title="Zoom In"
+		class="flex items-center justify-center gap-2 border-b border-text/10 p-2 text-text/50 transition-colors hover:bg-text/5 hover:text-text/70"
+		onclick={() => (isExpanded = !isExpanded)}
+		title={isExpanded ? 'Collapse' : 'Expand'}
 	>
-		<ZoomInIcon class="h-5 w-5" />
-	</button>
-	<button
-		class="rounded p-2 text-text/70 transition-colors hover:bg-text/10 hover:text-text disabled:opacity-30 disabled:hover:bg-transparent"
-		onclick={onZoomOut}
-		disabled={scale <= minScale}
-		title="Zoom Out"
-	>
-		<ZoomOutIcon class="h-5 w-5" />
-	</button>
-
-	<div class="my-1 h-px w-6 bg-text/20"></div>
-
-	<button
-		class="rounded p-2 text-text/70 transition-colors hover:bg-text/10 hover:text-text"
-		onclick={onFitHeight}
-		title="Fit Height"
-	>
-		<FitPageIcon class="h-5 w-5" />
+		{#if isExpanded}
+			<CollapseIcon class="h-4 w-4" />
+			<span class="text-xs">Collapse</span>
+		{:else}
+			<ExpandIcon class="h-4 w-4" />
+		{/if}
 	</button>
 
-	<div class="my-1 h-px w-6 bg-text/20"></div>
+	<div class="flex flex-col items-center gap-1 py-3 {isExpanded ? 'px-2' : ''}">
+		<!-- Zoom Controls -->
+		<div class="flex {isExpanded ? 'w-full justify-between' : 'flex-col'} items-center gap-1">
+			<button
+				class="{buttonClass} {isExpanded ? 'flex-1' : ''}"
+				onclick={onZoomIn}
+				disabled={scale >= maxScale}
+				title="Zoom In"
+			>
+				<span class="flex items-center gap-2">
+					<ZoomInIcon class="h-5 w-5" />
+					{#if isExpanded}<span class="text-xs">Zoom In</span>{/if}
+				</span>
+			</button>
+			<button
+				class="{buttonClass} {isExpanded ? 'flex-1' : ''}"
+				onclick={onZoomOut}
+				disabled={scale <= minScale}
+				title="Zoom Out"
+			>
+				<span class="flex items-center gap-2">
+					<ZoomOutIcon class="h-5 w-5" />
+					{#if isExpanded}<span class="text-xs">Zoom Out</span>{/if}
+				</span>
+			</button>
+		</div>
 
-	<!-- Page Navigation -->
-	<button
-		class="rounded p-2 text-text/70 transition-colors hover:bg-text/10 hover:text-text disabled:opacity-30 disabled:hover:bg-transparent"
-		onclick={onPrevPage}
-		disabled={pageNumber <= 1}
-		title="Previous Page"
-	>
-		<ChevronUpIcon class="h-5 w-5" />
-	</button>
-	<span class="text-xs text-text/70">{pageNumber}/{numPages}</span>
-	<button
-		class="rounded p-2 text-text/70 transition-colors hover:bg-text/10 hover:text-text disabled:opacity-30 disabled:hover:bg-transparent"
-		onclick={onNextPage}
-		disabled={pageNumber >= numPages}
-		title="Next Page"
-	>
-		<ChevronDownIcon class="h-5 w-5" />
-	</button>
+		<div class="my-1 h-px w-full bg-text/20"></div>
+
+		<button
+			class="{buttonClass} {isExpanded ? 'w-full justify-start' : ''}"
+			onclick={onFitHeight}
+			title="Fit Height"
+		>
+			<span class="flex items-center gap-2">
+				<FitPageIcon class="h-5 w-5" />
+				{#if isExpanded}<span class="text-xs">Fit Height</span>{/if}
+			</span>
+		</button>
+
+		<div class="my-1 h-px w-full bg-text/20"></div>
+
+		{#if numPages > 1}
+			<!-- Page Navigation -->
+			<div class="flex {isExpanded ? 'w-full justify-between' : 'flex-col'} items-center gap-1">
+				<button
+					class="{buttonClass} {isExpanded ? '' : ''}"
+					onclick={onPrevPage}
+					disabled={pageNumber <= 1}
+					title="Previous Page"
+				>
+					<ChevronUpIcon class="h-5 w-5" />
+				</button>
+				<span class="text-xs text-text/70 {isExpanded ? 'mx-2' : ''}">{pageNumber}/{numPages}</span>
+				<button
+					class="{buttonClass} {isExpanded ? '' : ''}"
+					onclick={onNextPage}
+					disabled={pageNumber >= numPages}
+					title="Next Page"
+				>
+					<ChevronDownIcon class="h-5 w-5" />
+				</button>
+			</div>
+
+			<div class="my-1 h-px w-full bg-text/20"></div>
+		{/if}
+
+		<!-- View Mode Selector (admin/owner only) -->
+		<ViewModeSelector {isExpanded} />
+
+		<div class="my-1 h-px w-full bg-text/20"></div>
+
+		<!-- My Comments Only Toggle -->
+		<button
+			class="{documentStore.showOnlyMyComments ? activeButtonClass : buttonClass} {isExpanded
+				? 'w-full justify-start'
+				: ''}"
+			onclick={() => documentStore.setShowOnlyMyComments(!documentStore.showOnlyMyComments)}
+			title={documentStore.showOnlyMyComments ? 'Show all comments' : 'Show only my comments'}
+		>
+			<span class="flex items-center gap-2">
+				<PersonIcon class="h-5 w-5" />
+				{#if isExpanded}<span class="text-xs"
+						>{documentStore.showOnlyMyComments ? 'My Comments' : 'All Comments'}</span
+					>{/if}
+			</span>
+		</button>
+
+		{#if documentStore.hasActiveFilter}
+			<button
+				class="text-xs text-primary/70 transition-colors hover:text-primary {isExpanded
+					? 'w-full px-2 text-left'
+					: ''}"
+				onclick={() => documentStore.clearFilters()}
+			>
+				{isExpanded ? 'Clear filters' : 'x'}
+			</button>
+		{/if}
+
+		<div class="my-1 h-px w-full bg-text/20"></div>
+
+		<!-- Active Users -->
+		<ActiveUsers {isExpanded} />
+	</div>
 </div>

--- a/frontend/src/lib/components/pdf/UserCursors.svelte
+++ b/frontend/src/lib/components/pdf/UserCursors.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+	import { documentWebSocket, type UserCursor } from '$lib/stores/documentWebSocket';
+	import { fade } from 'svelte/transition';
+
+	interface Props {
+		viewerContainer: HTMLDivElement | null;
+	}
+
+	let { viewerContainer }: Props = $props();
+
+	// Subscribe to user cursors
+	let cursorsMap: Map<number, UserCursor> = $state(new Map());
+
+	$effect(() => {
+		const unsubscribe = documentWebSocket.userCursors.subscribe((cursors) => {
+			cursorsMap = cursors;
+		});
+		return unsubscribe;
+	});
+
+	// Get page element for a specific page number
+	const getPageElement = (pageNumber: number): HTMLElement | null => {
+		if (!viewerContainer) return null;
+		return viewerContainer.querySelector(
+			`[data-page-number="${pageNumber}"]`
+		) as HTMLElement | null;
+	};
+
+	// Calculate absolute position for a cursor
+	const getCursorPosition = (cursor: UserCursor): { x: number; y: number } | null => {
+		const pageEl = getPageElement(cursor.page);
+		if (!pageEl) return null;
+
+		const containerRect = viewerContainer?.getBoundingClientRect();
+		const pageRect = pageEl.getBoundingClientRect();
+		if (!containerRect) return null;
+
+		// Convert normalized coordinates to absolute position within viewer
+		const x = pageRect.left - containerRect.left + cursor.x * pageRect.width;
+		const y = pageRect.top - containerRect.top + cursor.y * pageRect.height;
+
+		return { x, y };
+	};
+
+	// Generate a consistent color based on user ID
+	const getUserColor = (userId: number): string => {
+		const colors = [
+			'#3b82f6', // blue
+			'#22c55e', // green
+			'#a855f7', // purple
+			'#f97316', // orange
+			'#ec4899', // pink
+			'#14b8a6', // teal
+			'#6366f1', // indigo
+			'#f43f5e' // rose
+		];
+		return colors[userId % colors.length];
+	};
+
+	// Track mouse movement on PDF and send position updates
+	const handleMouseMove = (e: MouseEvent) => {
+		if (!viewerContainer) return;
+
+		// Find which page the mouse is over
+		const pages = viewerContainer.querySelectorAll('[data-page-number]') as NodeListOf<HTMLElement>;
+
+		for (const pageEl of pages) {
+			const pageRect = pageEl.getBoundingClientRect();
+
+			// Check if mouse is within this page
+			if (
+				e.clientX >= pageRect.left &&
+				e.clientX <= pageRect.right &&
+				e.clientY >= pageRect.top &&
+				e.clientY <= pageRect.bottom
+			) {
+				const pageNumber = parseInt(pageEl.getAttribute('data-page-number') || '1', 10);
+
+				// Normalize coordinates relative to page
+				const x = (e.clientX - pageRect.left) / pageRect.width;
+				const y = (e.clientY - pageRect.top) / pageRect.height;
+
+				documentWebSocket.sendMousePosition(x, y, pageNumber, true);
+				return;
+			}
+		}
+	};
+
+	// Handle mouse leaving the PDF area
+	const handleMouseLeave = () => {
+		documentWebSocket.sendMousePosition(0, 0, 1, false);
+	};
+
+	// Attach mouse event listeners
+	$effect(() => {
+		if (!viewerContainer) return;
+
+		viewerContainer.addEventListener('mousemove', handleMouseMove);
+		viewerContainer.addEventListener('mouseleave', handleMouseLeave);
+
+		return () => {
+			viewerContainer.removeEventListener('mousemove', handleMouseMove);
+			viewerContainer.removeEventListener('mouseleave', handleMouseLeave);
+			// Send hidden cursor when leaving document page
+			documentWebSocket.sendMousePosition(0, 0, 1, false);
+		};
+	});
+
+	// Cleanup timer to hide stale cursors
+	// TTL: 200ms (4x the 50ms throttle interval) - cursors disappear quickly when user stops sending
+	const CURSOR_TTL_MS = 200;
+	const CLEANUP_INTERVAL_MS = 100;
+
+	$effect(() => {
+		const interval = setInterval(() => {
+			const now = Date.now();
+			let hasChanges = false;
+			cursorsMap.forEach((cursor, userId) => {
+				if (cursor.visible && now - cursor.lastUpdate > CURSOR_TTL_MS) {
+					// Mark as invisible if stale
+					cursorsMap.set(userId, { ...cursor, visible: false });
+					hasChanges = true;
+				}
+			});
+			if (hasChanges) {
+				// eslint-disable-next-line svelte/prefer-svelte-reactivity
+				cursorsMap = new Map(cursorsMap);
+			}
+		}, CLEANUP_INTERVAL_MS);
+
+		return () => clearInterval(interval);
+	});
+</script>
+
+<!-- Cursor overlay layer - positioned within the PDF viewer container -->
+{#each cursorsMap.entries() as [userId, cursor] (userId)}
+	{@const position = getCursorPosition(cursor)}
+	{#if cursor.visible && position}
+		<div
+			class="pointer-events-none absolute z-50 transition-all duration-75"
+			style="left: {position.x}px; top: {position.y}px;"
+			out:fade={{ duration: 400, delay: 2000 }}
+		>
+			<!-- Cursor pointer SVG -->
+			<svg
+				class="h-5 w-5 -translate-x-0.5 -translate-y-0.5 drop-shadow-md"
+				viewBox="0 0 24 24"
+				fill={getUserColor(cursor.user_id)}
+				stroke="white"
+				stroke-width="1.5"
+			>
+				<path
+					d="M5.5 3.21V20.8c0 .45.54.67.85.35l4.86-4.86a.5.5 0 0 1 .35-.15h6.87a.5.5 0 0 0 .35-.85L6.35 2.86a.5.5 0 0 0-.85.35Z"
+				/>
+			</svg>
+			<!-- Username label -->
+			<div
+				class="absolute top-3 left-4 rounded-full px-2 py-0.5 text-[10px] font-medium whitespace-nowrap text-white shadow-md"
+				style="background-color: {getUserColor(cursor.user_id)};"
+			>
+				{cursor.username}
+			</div>
+		</div>
+	{/if}
+{/each}

--- a/frontend/src/lib/components/pdf/ViewModeSelector.svelte
+++ b/frontend/src/lib/components/pdf/ViewModeSelector.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import { api } from '$api/client';
+	import type { ViewMode1 } from '$api/types';
+	import { documentStore } from '$lib/runes/document.svelte.js';
+	import { sessionStore } from '$lib/runes/session.svelte.js';
+	import { notification } from '$lib/stores/notificationStore';
+	import LockIcon from '~icons/material-symbols/lock';
+	import PublicIcon from '~icons/material-symbols/public';
+
+	interface Props {
+		isExpanded?: boolean;
+	}
+
+	let { isExpanded = false }: Props = $props();
+
+	// Only admins and owners can change view mode
+	let canChangeViewMode = $derived(
+		sessionStore.currentMembership?.is_owner ||
+			sessionStore.currentMembership?.permissions.includes('administrator')
+	);
+
+	let currentViewMode = $derived(documentStore.loadedDocument?.view_mode ?? 'public');
+	let isUpdating = $state(false);
+
+	const viewModes: { mode: ViewMode1; icon: typeof LockIcon; label: string; shortLabel: string }[] =
+		[
+			{
+				mode: 'restricted',
+				icon: LockIcon,
+				label: 'Restricted - Owner, admins & users with permission see comments',
+				shortLabel: 'Restricted'
+			},
+			{
+				mode: 'public',
+				icon: PublicIcon,
+				label: 'Public - Comments visible based on their visibility settings',
+				shortLabel: 'Public'
+			}
+		];
+
+	const setViewMode = async (mode: ViewMode1) => {
+		if (!canChangeViewMode || isUpdating || mode === currentViewMode) return;
+		if (!documentStore.loadedDocument) return;
+
+		const previousMode = documentStore.loadedDocument.view_mode;
+		isUpdating = true;
+
+		// Optimistically update local state
+		documentStore.loadedDocument.view_mode = mode;
+
+		const result = await api.update(`/documents/${documentStore.loadedDocument.id}`, {
+			view_mode: mode
+		});
+
+		if (!result.success) {
+			// Revert on failure
+			documentStore.loadedDocument.view_mode = previousMode;
+			notification(result.error);
+		}
+		// On success, WebSocket will also broadcast this to other users
+		isUpdating = false;
+	};
+</script>
+
+{#if canChangeViewMode}
+	<div class="flex {isExpanded ? 'w-full flex-col' : 'flex-col items-center'} gap-0.5">
+		{#each viewModes as { mode, icon: Icon, label, shortLabel } (mode)}
+			<button
+				class="rounded p-1.5 transition-colors {currentViewMode === mode
+					? 'bg-primary/20 text-primary'
+					: 'text-text/50 hover:bg-text/10 hover:text-text/70'} disabled:opacity-50 {isExpanded
+					? 'w-full'
+					: ''}"
+				onclick={() => setViewMode(mode)}
+				disabled={isUpdating}
+				title={label}
+			>
+				<span class="flex items-center gap-2">
+					<Icon class="h-4 w-4" />
+					{#if isExpanded}<span class="text-xs">{shortLabel}</span>{/if}
+				</span>
+			</button>
+		{/each}
+	</div>
+{/if}

--- a/frontend/src/lib/components/pdf/ViewModeSelector.svelte
+++ b/frontend/src/lib/components/pdf/ViewModeSelector.svelte
@@ -62,17 +62,18 @@
 	};
 </script>
 
-{#if canChangeViewMode}
-	<div class="flex {isExpanded ? 'w-full flex-col' : 'flex-col items-center'} gap-0.5">
+<div class="flex {isExpanded ? 'w-full flex-col' : 'flex-col items-center'} gap-0.5">
 		{#each viewModes as { mode, icon: Icon, label, shortLabel } (mode)}
+			<!-- Render view mode buttons; only apply hover styles when the user can change view mode -->
 			<button
 				class="rounded p-1.5 transition-colors {currentViewMode === mode
 					? 'bg-primary/20 text-primary'
-					: 'text-text/50 hover:bg-text/10 hover:text-text/70'} disabled:opacity-50 {isExpanded
+					: (canChangeViewMode ? 'text-text/50 hover:bg-text/10 hover:text-text/70' : 'text-text/50')} disabled:opacity-50 {isExpanded
 					? 'w-full'
 					: ''}"
 				onclick={() => setViewMode(mode)}
-				disabled={isUpdating}
+				disabled={isUpdating || !canChangeViewMode}
+				aria-disabled={isUpdating || !canChangeViewMode}
 				title={label}
 			>
 				<span class="flex items-center gap-2">
@@ -82,4 +83,3 @@
 			</button>
 		{/each}
 	</div>
-{/if}

--- a/frontend/src/lib/components/pdf/ViewModeSelector.svelte
+++ b/frontend/src/lib/components/pdf/ViewModeSelector.svelte
@@ -63,23 +63,23 @@
 </script>
 
 <div class="flex {isExpanded ? 'w-full flex-col' : 'flex-col items-center'} gap-0.5">
-		{#each viewModes as { mode, icon: Icon, label, shortLabel } (mode)}
-			<!-- Render view mode buttons; only apply hover styles when the user can change view mode -->
-			<button
-				class="rounded p-1.5 transition-colors {currentViewMode === mode
-					? 'bg-primary/20 text-primary'
-					: (canChangeViewMode ? 'text-text/50 hover:bg-text/10 hover:text-text/70' : 'text-text/50')} disabled:opacity-50 {isExpanded
-					? 'w-full'
-					: ''}"
-				onclick={() => setViewMode(mode)}
-				disabled={isUpdating || !canChangeViewMode}
-				aria-disabled={isUpdating || !canChangeViewMode}
-				title={label}
-			>
-				<span class="flex items-center gap-2">
-					<Icon class="h-4 w-4" />
-					{#if isExpanded}<span class="text-xs">{shortLabel}</span>{/if}
-				</span>
-			</button>
-		{/each}
-	</div>
+	{#each viewModes as { mode, icon: Icon, label, shortLabel } (mode)}
+		<!-- Render view mode buttons; only apply hover styles when the user can change view mode -->
+		<button
+			class="rounded p-1.5 transition-colors {currentViewMode === mode
+				? 'bg-primary/20 text-primary'
+				: canChangeViewMode
+					? 'text-text/50 hover:bg-text/10 hover:text-text/70'
+					: 'text-text/50'} disabled:opacity-50 {isExpanded ? 'w-full' : ''}"
+			onclick={() => setViewMode(mode)}
+			disabled={isUpdating || !canChangeViewMode}
+			aria-disabled={isUpdating || !canChangeViewMode}
+			title={label}
+		>
+			<span class="flex items-center gap-2">
+				<Icon class="h-4 w-4" />
+				{#if isExpanded}<span class="text-xs">{shortLabel}</span>{/if}
+			</span>
+		</button>
+	{/each}
+</div>

--- a/frontend/src/lib/runes/document.svelte.ts
+++ b/frontend/src/lib/runes/document.svelte.ts
@@ -5,7 +5,7 @@ import type {
 	CommentRead,
 	CommentUpdate,
 	DocumentRead,
-	ViewMode1,
+	ViewMode1
 } from '$api/types';
 import type { Paginated } from '$api/pagination';
 import { notification } from '$lib/stores/notificationStore';
@@ -284,7 +284,11 @@ const createDocumentStore = () => {
 		return replies;
 	};
 
-	const handleWebSocketEvent = (event: CommentEvent | { type: 'view_mode_changed'; payload: { document_id?: string; view_mode?: ViewMode1 } }): void => {
+	const handleWebSocketEvent = (
+		event:
+			| CommentEvent
+			| { type: 'view_mode_changed'; payload: { document_id?: string; view_mode?: ViewMode1 } }
+	): void => {
 		// Handle explicit view-mode changed events (no longer delivered as 'custom')
 		if (event.type === 'view_mode_changed') {
 			const vm = event.payload as { document_id?: string; view_mode?: ViewMode1 };
@@ -306,21 +310,21 @@ const createDocumentStore = () => {
 			case 'create':
 				{
 					const comment = event.payload as CommentRead;
-				if (comment.parent_id) {
-					const parentComment = findComment(comments, comment.parent_id);
-					if (parentComment) {
-						// Only add to replies array if replies are already loaded unless the number of replies was 0 then we can safely add it
-						if (parentComment.replies) {
-							parentComment.replies.push(toCachedComment(comment));
-						} else if (parentComment.num_replies === 0) {
-							parentComment.replies = [toCachedComment(comment)];
+					if (comment.parent_id) {
+						const parentComment = findComment(comments, comment.parent_id);
+						if (parentComment) {
+							// Only add to replies array if replies are already loaded unless the number of replies was 0 then we can safely add it
+							if (parentComment.replies) {
+								parentComment.replies.push(toCachedComment(comment));
+							} else if (parentComment.num_replies === 0) {
+								parentComment.replies = [toCachedComment(comment)];
+							}
+							parentComment.num_replies = (parentComment.num_replies || 0) + 1;
 						}
-						parentComment.num_replies = (parentComment.num_replies || 0) + 1;
+						comments = [...comments]; // trigger reactivity
+					} else {
+						comments = [...comments, toCachedComment(comment)];
 					}
-					comments = [...comments]; // trigger reactivity
-				} else {
-					comments = [...comments, toCachedComment(comment)];
-				}
 				}
 				break;
 

--- a/frontend/src/lib/runes/session.svelte.ts
+++ b/frontend/src/lib/runes/session.svelte.ts
@@ -27,7 +27,11 @@ const createSessionStore = () => {
 		// Handle logical combinations of permissions
 		if (Array.isArray(requiredPermissions)) {
 			// Default behavior: all permissions must be present (AND logic)
-			if (!requiredPermissions.every((permission) => currentMembership?.permissions.includes(permission))) {
+			if (
+				!requiredPermissions.every((permission) =>
+					currentMembership?.permissions.includes(permission)
+				)
+			) {
 				if (redirectUrl) {
 					redirect(303, redirectUrl);
 				}
@@ -72,7 +76,7 @@ const createSessionStore = () => {
 		set currentMembership(membership: MembershipRead | null) {
 			currentMembership = membership;
 		},
-		validatePermissions,
+		validatePermissions
 	};
 };
 

--- a/frontend/src/lib/runes/session.svelte.ts
+++ b/frontend/src/lib/runes/session.svelte.ts
@@ -16,19 +16,18 @@ const createSessionStore = () => {
 	 * Admin and owner always pass validation.
 	 */
 	const validatePermissions = (
-		membership: Partial<MembershipRead> & Pick<MembershipRead, 'permissions'>,
 		requiredPermissions: Permission[] | { and?: Permission[]; or?: Permission[] },
 		redirectUrl?: string | URL
 	): boolean => {
 		// Admin override
-		if (membership.permissions.includes('administrator') || membership.is_owner) {
+		if (currentMembership?.permissions.includes('administrator') || currentMembership?.is_owner) {
 			return true;
 		}
 
 		// Handle logical combinations of permissions
 		if (Array.isArray(requiredPermissions)) {
 			// Default behavior: all permissions must be present (AND logic)
-			if (!requiredPermissions.every((permission) => membership.permissions.includes(permission))) {
+			if (!requiredPermissions.every((permission) => currentMembership?.permissions.includes(permission))) {
 				if (redirectUrl) {
 					redirect(303, redirectUrl);
 				}
@@ -38,7 +37,7 @@ const createSessionStore = () => {
 			const { and, or } = requiredPermissions;
 
 			// Check AND conditions
-			if (and && !and.every((permission) => membership.permissions.includes(permission))) {
+			if (and && !and.every((permission) => currentMembership?.permissions.includes(permission))) {
 				if (redirectUrl) {
 					redirect(303, redirectUrl);
 				}
@@ -46,7 +45,7 @@ const createSessionStore = () => {
 			}
 
 			// Check OR conditions
-			if (or && !or.some((permission) => membership.permissions.includes(permission))) {
+			if (or && !or.some((permission) => currentMembership?.permissions.includes(permission))) {
 				if (redirectUrl) {
 					redirect(303, redirectUrl);
 				}
@@ -55,20 +54,6 @@ const createSessionStore = () => {
 		}
 
 		return true;
-	};
-
-	/**
-	 * Checks if the current user can perform an action on a comment.
-	 * User can delete their own comments or if they have remove_comments permission.
-	 */
-	const canModifyComment = (commentUserId: number | null): boolean => {
-		if (!currentUser || !currentMembership) return false;
-
-		// User owns the comment
-		if (commentUserId === currentUser.id) return true;
-
-		// User has permission to remove comments
-		return validatePermissions(currentMembership, ['remove_comments']);
 	};
 
 	return {
@@ -88,7 +73,6 @@ const createSessionStore = () => {
 			currentMembership = membership;
 		},
 		validatePermissions,
-		canModifyComment
 	};
 };
 

--- a/frontend/src/lib/stores/documentWebSocket.ts
+++ b/frontend/src/lib/stores/documentWebSocket.ts
@@ -1,4 +1,4 @@
-import { writable, derived } from 'svelte/store';
+import { writable, derived, get } from 'svelte/store';
 import { WebSocketManager } from '$lib/websocket/manager';
 import type { ConnectionState } from '$types/websocket';
 import { browser } from '$app/environment';
@@ -6,17 +6,98 @@ import { api } from '$api/client';
 import { env } from '$env/dynamic/public';
 import type { CommentEvent } from '$api/types';
 
+/** Represents a user connected to a document */
+export interface ConnectedUser {
+	user_id: number;
+	username: string;
+	connection_id: string;
+	connected_at: string;
+}
+
+/** Represents a user's cursor position */
+export interface UserCursor {
+	user_id: number;
+	username: string;
+	x: number; // Normalized 0-1
+	y: number; // Normalized 0-1
+	page: number;
+	visible: boolean;
+	lastUpdate: number; // Timestamp for cleanup
+}
+
+/** Handshake response from server */
+interface HandshakeEvent {
+	type: 'handshake';
+	payload: {
+		connection_id: string;
+		active_users: ConnectedUser[];
+	};
+}
+
+/** User connected event */
+interface UserConnectedEvent {
+	type: 'user_connected';
+	payload: ConnectedUser;
+	originating_connection_id?: string;
+}
+
+/** User disconnected event */
+interface UserDisconnectedEvent {
+	type: 'user_disconnected';
+	payload: {
+		user_id: number;
+	};
+}
+
+/** Mouse position event from other users */
+interface MousePositionEvent {
+	type: 'mouse_position';
+	payload: {
+		user_id: number;
+		username: string;
+		x: number;
+		y: number;
+		page: number;
+		visible: boolean;
+	};
+	originating_connection_id?: string;
+}
+
+/** All possible WebSocket event types */
+type WebSocketEvent =
+	| CommentEvent
+	| HandshakeEvent
+	| UserConnectedEvent
+	| UserDisconnectedEvent
+	| MousePositionEvent;
+
 /**
- * WebSocket connection for a specific document
+ * WebSocket connection for a specific document with active user tracking
  */
 class DocumentWebSocketStore {
 	private manager: WebSocketManager | null = null;
+	private currentConnectionId: string | null = null;
 
 	// Connection state
 	private stateStore = writable<ConnectionState>('disconnected');
 
+	// Active users in the document
+	private activeUsersStore = writable<ConnectedUser[]>([]);
+
+	// User cursor positions (keyed by user_id)
+	private userCursorsStore = writable<Map<number, UserCursor>>(new Map());
+
 	// Export as readonly
 	public readonly state = derived(this.stateStore, ($state) => $state);
+	public readonly activeUsers = derived(this.activeUsersStore, ($users) => $users);
+	public readonly userCursors = derived(this.userCursorsStore, ($cursors) => $cursors);
+
+	// Internal event handlers
+	private commentEventHandlers: ((event: CommentEvent) => void)[] = [];
+
+	// Throttle tracking for mouse position sending
+	private lastMouseSendTime = 0;
+	private mouseThrottleMs = 50; // Send at most every 50ms
 
 	/**
 	 * Initialize WebSocket connection for a document
@@ -27,8 +108,6 @@ class DocumentWebSocketStore {
 
 		// Disconnect any existing connection
 		this.disconnect();
-
-		// Get connection ID from API client
 
 		const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
 		const host = env.PUBLIC_BACKEND_BASEURL.replace(/^https?:\/\//, '').replace(/\/$/, '');
@@ -47,8 +126,76 @@ class DocumentWebSocketStore {
 			this.stateStore.set(state);
 		});
 
+		// Handle all incoming messages
+		this.manager.on<WebSocketEvent>('message', (event) => {
+			this.handleEvent(event);
+		});
+
 		// Connect
 		this.manager.connect();
+	}
+
+	/**
+	 * Handle incoming WebSocket events
+	 */
+	private handleEvent(event: WebSocketEvent): void {
+		switch (event.type) {
+			case 'handshake':
+				// Initial handshake - set connection ID and active users
+				this.currentConnectionId = event.payload.connection_id;
+				this.activeUsersStore.set(event.payload.active_users);
+				console.log('[WS] Handshake received, active users:', event.payload.active_users.length);
+				break;
+
+			case 'user_connected':
+				// Skip our own connection event
+				if (event.originating_connection_id === this.currentConnectionId) break;
+				// Add new user to the list
+				this.activeUsersStore.update((users) => {
+					// Don't add if already exists
+					if (users.some((u) => u.user_id === event.payload.user_id)) return users;
+					return [...users, event.payload];
+				});
+				console.log('[WS] User connected:', event.payload.username);
+				break;
+
+			case 'user_disconnected':
+				// Remove user from the list
+				this.activeUsersStore.update((users) =>
+					users.filter((u) => u.user_id !== event.payload.user_id)
+				);
+				// Also remove their cursor
+				this.userCursorsStore.update((cursors) => {
+					cursors.delete(event.payload.user_id);
+					return new Map(cursors);
+				});
+				console.log('[WS] User disconnected:', event.payload.user_id);
+				break;
+
+			case 'mouse_position':
+				// Update cursor position for this user
+				this.userCursorsStore.update((cursors) => {
+					cursors.set(event.payload.user_id, {
+						user_id: event.payload.user_id,
+						username: event.payload.username,
+						x: event.payload.x,
+						y: event.payload.y,
+						page: event.payload.page,
+						visible: event.payload.visible,
+						lastUpdate: Date.now()
+					});
+					return new Map(cursors);
+				});
+				break;
+
+			case 'create':
+			case 'update':
+			case 'delete':
+			case 'custom':
+				// Forward comment events to registered handlers
+				this.commentEventHandlers.forEach((handler) => handler(event as CommentEvent));
+				break;
+		}
 	}
 
 	/**
@@ -60,18 +207,51 @@ class DocumentWebSocketStore {
 			this.manager = null;
 		}
 		this.stateStore.set('disconnected');
+		this.activeUsersStore.set([]);
+		this.userCursorsStore.set(new Map());
+		this.currentConnectionId = null;
+		this.commentEventHandlers = [];
+	}
+
+	/**
+	 * Send mouse position update (throttled)
+	 */
+	sendMousePosition(x: number, y: number, page: number, visible: boolean = true): void {
+		const now = Date.now();
+		if (now - this.lastMouseSendTime < this.mouseThrottleMs) {
+			return; // Throttle
+		}
+		this.lastMouseSendTime = now;
+
+		this.send({
+			type: 'mouse_position',
+			payload: { x, y, page, visible }
+		});
 	}
 
 	/**
 	 * Subscribe to comment events
+	 * Returns an unsubscribe function
 	 */
 	onCommentEvent(handler: (event: CommentEvent) => void): () => void {
-		if (!this.manager) {
-			console.warn('Cannot subscribe to comment events: WebSocket not connected');
-			return () => {};
-		}
+		this.commentEventHandlers.push(handler);
+		return () => {
+			this.commentEventHandlers = this.commentEventHandlers.filter((h) => h !== handler);
+		};
+	}
 
-		return this.manager.on<CommentEvent>('message', handler);
+	/**
+	 * Get the current connection ID
+	 */
+	getConnectionId(): string | null {
+		return this.currentConnectionId;
+	}
+
+	/**
+	 * Get active users as a plain array (for non-store contexts)
+	 */
+	getActiveUsers(): ConnectedUser[] {
+		return get(this.activeUsersStore);
 	}
 
 	/**

--- a/frontend/src/lib/stores/documentWebSocket.ts
+++ b/frontend/src/lib/stores/documentWebSocket.ts
@@ -4,7 +4,11 @@ import type { ConnectionState } from '$types/websocket';
 import { browser } from '$app/environment';
 import { api } from '$api/client';
 import { env } from '$env/dynamic/public';
-import type { CommentEvent, ViewModeChangedEvent as ApiViewModeChangedEvent, MousePositionEvent as ApiMousePositionEvent } from '$api/types';
+import type {
+	CommentEvent,
+	ViewModeChangedEvent as ApiViewModeChangedEvent,
+	MousePositionEvent as ApiMousePositionEvent
+} from '$api/types';
 
 /** Represents a user connected to a document */
 export interface ConnectedUser {
@@ -189,14 +193,14 @@ class DocumentWebSocketStore {
 			case 'create':
 			case 'update':
 			case 'delete':
-					// Forward comment events to registered handlers
-					this.commentEventHandlers.forEach((handler) => handler(event as CommentEvent));
-					break;
+				// Forward comment events to registered handlers
+				this.commentEventHandlers.forEach((handler) => handler(event as CommentEvent));
+				break;
 
 			case 'view_mode_changed':
-					// Notify registered view-mode handlers
-					this.viewModeEventHandlers.forEach((handler) => handler(event as ViewModeChangedEvent));
-					break;
+				// Notify registered view-mode handlers
+				this.viewModeEventHandlers.forEach((handler) => handler(event as ViewModeChangedEvent));
+				break;
 		}
 	}
 

--- a/frontend/src/routes/+page.ts
+++ b/frontend/src/routes/+page.ts
@@ -1,6 +1,6 @@
-import { redirect } from "@sveltejs/kit";
-import type { PageLoad } from "./$types";
+import { redirect } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
 
 export const load: PageLoad = async () => {
-    return redirect(308, "/dashboard");
+	return redirect(308, '/dashboard');
 };

--- a/frontend/src/routes/dashboard/groups/[groupid]/+layout.svelte
+++ b/frontend/src/routes/dashboard/groups/[groupid]/+layout.svelte
@@ -26,7 +26,7 @@
 			path: '/settings',
 			i18nKey: $LL.group.settings,
 			icon: SettingsIcon,
-			condition: sessionStore.validatePermissions(data.membership, ['administrator'])
+			condition: sessionStore.validatePermissions(['administrator'])
 		}
 	];
 

--- a/frontend/src/routes/dashboard/groups/[groupid]/documents/+page.svelte
+++ b/frontend/src/routes/dashboard/groups/[groupid]/documents/+page.svelte
@@ -27,7 +27,7 @@
 <div class="h-screen p-4">
 	<div class="mb-4 flex w-full flex-row items-center justify-between gap-2">
 		<h1 class="text-2xl font-bold">Documents</h1>
-		{#if sessionStore.validatePermissions(data.membership, ['upload_documents'])}
+		{#if sessionStore.validatePermissions(['upload_documents'])}
 			<a
 				href="/dashboard/groups/{group.id}/documents/create"
 				class="flex flex-row items-center gap-2 rounded bg-green-500/30 px-3 py-2.5 font-semibold shadow-inner shadow-black/30 transition hover:cursor-pointer hover:bg-green-500/40"

--- a/frontend/src/routes/dashboard/groups/[groupid]/memberships/+page.svelte
+++ b/frontend/src/routes/dashboard/groups/[groupid]/memberships/+page.svelte
@@ -341,7 +341,7 @@
 					})}
 				>
 					{#snippet icon()}
-						{#if sessionStore.validatePermissions(['manage_permissions']) && availablePermissions.filter((p) => !membership.permissions.includes(p)).length > 0}
+						{#if sessionStore.validatePermissions( ['manage_permissions'] ) && availablePermissions.filter((p) => !membership.permissions.includes(p)).length > 0}
 							<AddIcon
 								class="h-full w-5.5 rounded bg-background text-text shadow-inner shadow-black/20 transition-all hover:bg-green-500/30"
 							/>

--- a/frontend/src/routes/dashboard/groups/[groupid]/memberships/+page.svelte
+++ b/frontend/src/routes/dashboard/groups/[groupid]/memberships/+page.svelte
@@ -130,7 +130,7 @@
 <div class="h-screen p-4">
 	<div class="mb-4 flex w-full flex-row items-center justify-between gap-2">
 		<h1 class="text-2xl font-bold">Member Management</h1>
-		{#if sessionStore.validatePermissions(data.membership, ['add_members'])}
+		{#if sessionStore.validatePermissions(['add_members'])}
 			<!--INVITE-->
 			<div class="flex flex-row items-end gap-2">
 				<div class="w-64">
@@ -166,7 +166,7 @@
 				<p class="mr-2 font-semibold">{selected.length}/{data.memberships.total} Selected:</p>
 			{/if}
 			{#if selected.length > 0}
-				{#if sessionStore.validatePermissions(data.membership, ['remove_members'])}
+				{#if sessionStore.validatePermissions(['remove_members'])}
 					<button
 						class="rounded bg-inset px-1 py-1.5 font-semibold shadow-inner shadow-black/30 transition hover:cursor-pointer hover:bg-red-500/30"
 						onclick={() => selected.forEach(async ({ user: { id } }) => kickMember(id))}
@@ -174,7 +174,7 @@
 						Kick
 					</button>
 				{/if}
-				{#if sessionStore.validatePermissions(data.membership, ['manage_permissions'])}
+				{#if sessionStore.validatePermissions(['manage_permissions'])}
 					<Dropdown
 						items={availablePermissions}
 						onSelect={(perm) =>
@@ -321,7 +321,7 @@
 			<Badge
 				item={perm}
 				label={$LL.permissions[perm]?.() || perm}
-				showRemove={sessionStore.validatePermissions(data.membership, ['manage_permissions'])}
+				showRemove={sessionStore.validatePermissions(['manage_permissions'])}
 				onRemove={() => removePermissionFromMembership(membership, perm)}
 			/>
 		{/each}
@@ -336,12 +336,12 @@
 					showArrow={false}
 					show={false}
 					hideCurrentSelection={true}
-					allowSelection={sessionStore.validatePermissions(data.membership, {
+					allowSelection={sessionStore.validatePermissions({
 						or: ['manage_permissions', 'remove_members']
 					})}
 				>
 					{#snippet icon()}
-						{#if sessionStore.validatePermissions( data.membership, ['manage_permissions'] ) && availablePermissions.filter((p) => !membership.permissions.includes(p)).length > 0}
+						{#if sessionStore.validatePermissions(['manage_permissions']) && availablePermissions.filter((p) => !membership.permissions.includes(p)).length > 0}
 							<AddIcon
 								class="h-full w-5.5 rounded bg-background text-text shadow-inner shadow-black/20 transition-all hover:bg-green-500/30"
 							/>
@@ -358,7 +358,7 @@
 
 {#snippet removeSnippet(membership: Omit<MembershipRead, 'group'>)}
 	{@const useRemoveButton =
-		sessionStore.validatePermissions(data.membership, ['remove_members']) &&
+		sessionStore.validatePermissions(['remove_members']) &&
 		!membership.is_owner &&
 		!(
 			membership.permissions.includes('administrator') ||

--- a/frontend/src/routes/dashboard/groups/[groupid]/settings/+page.svelte
+++ b/frontend/src/routes/dashboard/groups/[groupid]/settings/+page.svelte
@@ -23,7 +23,7 @@
 
 	let { data } = $props();
 	let group = $derived(data.membership.group);
-	let isOwner = $derived(sessionStore.validatePermissions(data.membership, []));
+	let isOwner = $derived(sessionStore.currentMembership?.is_owner);
 	let defaultPermissions: Permission[] = $derived(group.default_permissions || []);
 
 	let transferUsername: string = $state('');

--- a/frontend/src/routes/dashboard/groups/[groupid]/settings/+page.ts
+++ b/frontend/src/routes/dashboard/groups/[groupid]/settings/+page.ts
@@ -4,7 +4,6 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
 	const { membership, sessionUser } = await parent();
 	sessionStore.validatePermissions(
-		membership,
 		['administrator'],
 		`/dashboard/groups/${membership.group.id}/documents`
 	);

--- a/frontend/src/routes/documents/[documentid]/+page.svelte
+++ b/frontend/src/routes/documents/[documentid]/+page.svelte
@@ -18,17 +18,20 @@
 	// WebSocket connection lifecycle (separate effect with cleanup)
 	$effect(() => {
 		let wsUnsubscribe: (() => void) | null = null;
+		let vmUnsubscribe: (() => void) | null = null;
 
 		// Connect to WebSocket for real-time comment updates
 		documentWebSocket.connect(document.id.toString()).then(() => {
 			wsUnsubscribe = documentWebSocket.onCommentEvent((event) => {
 				documentStore.handleWebSocketEvent(event);
 			});
+			vmUnsubscribe = documentWebSocket.onViewModeChanged((ev) => documentStore.handleWebSocketEvent(ev as any));
 		});
 
 		// Cleanup when effect re-runs or component unmounts
 		return () => {
 			wsUnsubscribe?.();
+			vmUnsubscribe?.();
 			documentWebSocket.disconnect();
 			documentStore.clearAllInteractionState();
 		};

--- a/frontend/src/routes/documents/[documentid]/+page.svelte
+++ b/frontend/src/routes/documents/[documentid]/+page.svelte
@@ -25,7 +25,9 @@
 			wsUnsubscribe = documentWebSocket.onCommentEvent((event) => {
 				documentStore.handleWebSocketEvent(event);
 			});
-			vmUnsubscribe = documentWebSocket.onViewModeChanged((ev) => documentStore.handleWebSocketEvent(ev as any));
+			vmUnsubscribe = documentWebSocket.onViewModeChanged((ev) =>
+				documentStore.handleWebSocketEvent(ev as any)
+			);
 		});
 
 		// Cleanup when effect re-runs or component unmounts


### PR DESCRIPTION
This PR adds conditional checks to hide certain elements like comment delete or reply buttons based on permissions.
It also slightly reworks the websocket connection in frontend and backend to store active users for a document, and share and display them for clients. As part of this rework custom events can be sent where for now the view_mode of the document can be adjusted and the cursor position is shared live with other connected clients. It also adds a basic filtering system to comments where comments can be filtered by clicking on one of the active users toggling off all other comments besides the selected users.