### PR TITLE
Sidebar improvements and breadcrumbs

### DIFF
--- a/backend/app/models/group.py
+++ b/backend/app/models/group.py
@@ -23,6 +23,7 @@ class GroupRead(BaseModel):
     id: str
     name: str
     member_count: int
+    document_count: int
     owner: "UserRead | None"
     default_permissions: list[Permission]
 

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -153,6 +153,7 @@ export const groupReadSchema = z.object({
     id: z.string(),
     name: z.string(),
     member_count: z.number(),
+    document_count: z.number(),
     owner: userReadSchema.nullable(),
     default_permissions: z.array(permissionSchema)
 });

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -242,6 +242,7 @@ export interface GroupRead {
   id: string;
   name: string;
   member_count: number;
+  document_count: number;
   owner: UserRead | null;
   default_permissions: Permission[];
 }

--- a/frontend/src/lib/components/Breadcrumb.svelte
+++ b/frontend/src/lib/components/Breadcrumb.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import ChevronRight from '~icons/material-symbols/chevron-right';
+	import type { BreadcrumbItem } from '$types/breadcrumb';
+
+	// Read breadcrumbs from current page data
+	const breadcrumbs = $derived($page.data.breadcrumbs as BreadcrumbItem[] | undefined);
+</script>
+
+{#if breadcrumbs && breadcrumbs.length > 0}
+	<nav class="text-md flex items-center gap-2">
+		{#each breadcrumbs as crumb, i (crumb)}
+			{#if i > 0}
+				<ChevronRight class="h-4 w-4 text-text/30" />
+			{/if}
+
+			{#if crumb.href}
+				<a href={crumb.href} class="text-text/70 transition-colors hover:text-text">
+					{crumb.label}
+				</a>
+			{:else}
+				<span class="font-medium text-text">
+					{crumb.label}
+				</span>
+			{/if}
+		{/each}
+	</nav>
+{/if}

--- a/frontend/src/lib/components/membershipList.svelte
+++ b/frontend/src/lib/components/membershipList.svelte
@@ -115,10 +115,10 @@
 			<h2 class="w-full text-left text-2xl">{$LL.myGroups()}</h2>
 			<a
 				href="/dashboard/groups/create"
-				class="bg-inset flex flex-row items-center gap-1 rounded-md px-3 py-1 text-sm shadow-inner shadow-black/30 transition-all hover:bg-green-500/20"
+				class="flex flex-row items-center gap-1 rounded-md bg-inset px-3 py-1 text-sm shadow-inner shadow-black/30 transition-all hover:bg-green-500/20"
 				title="Create new group"
 			>
-				<AddIcon class="text-text h-4 w-4" />
+				<AddIcon class="h-4 w-4 text-text" />
 				<p class="text-text">New</p>
 			</a>
 		</div>
@@ -128,23 +128,28 @@
 		{#snippet itemSnippet(membership: Omit<MembershipRead, 'user'>)}
 			{#if compact}
 				<div
-					class="bg-primary/20 hover:bg-primary group m-1 flex w-full cursor-pointer items-center justify-center rounded-md py-2.5 shadow-inner shadow-black/30 transition-all"
+					class="group m-1 flex w-full cursor-pointer items-center justify-center rounded-md bg-primary/20 py-2.5 shadow-inner shadow-black/30 transition-all hover:bg-primary"
 					class:bg-primary={membership.group.id === page.params.groupid}
 					class:shadow-inner-sym-[5px]={membership.group.id === page.params.groupid}
 					title={membership.group.name}
 				>
-					<span class="text-text text-sm font-bold">{getInitials(membership.group.name)}</span>
+					<span class="text-sm font-bold text-text">{getInitials(membership.group.name)}</span>
 				</div>
 			{:else}
 				<div
-					class="bg-inset hover:bg-primary group m-1 flex w-full cursor-pointer flex-col gap-2 rounded-md px-3 py-2.5 shadow-inner shadow-black/30 transition-all"
+					class="group m-1 flex w-full cursor-pointer flex-col gap-2 rounded-md bg-inset px-3 py-2.5 shadow-inner shadow-black/30 transition-all hover:bg-primary"
 					class:bg-primary={membership.group.id === page.params.groupid}
 					class:shadow-inner-sym-[5px]={membership.group.id === page.params.groupid}
 				>
 					<h3 class="truncate text-left text-base font-semibold">{membership.group.name}</h3>
-					<div class="text-text/70 flex items-center gap-3 text-xs">
+					<div class="flex items-center gap-3 text-xs text-text/70">
 						<!-- Member count -->
-						<div class="flex items-center gap-1" title="{membership.group.member_count} member{membership.group.member_count === 1 ? '' : 's'}">
+						<div
+							class="flex items-center gap-1"
+							title="{membership.group.member_count} member{membership.group.member_count === 1
+								? ''
+								: 's'}"
+						>
 							<PeopleIcon class="h-4 w-4" />
 							<span>{membership.group.member_count}</span>
 						</div>
@@ -158,8 +163,13 @@
 						</div>
 						<!-- Owner indicator -->
 
-						<div class="ml-auto flex items-center" title={membership.is_owner ? 'You own this group' : ''}>
-							<CrownIcon class="h-4 w-4 {membership.is_owner ? 'text-yellow-500 hover:scale-110' : ''}" />
+						<div
+							class="ml-auto flex items-center"
+							title={membership.is_owner ? 'You own this group' : ''}
+						>
+							<CrownIcon
+								class="h-4 w-4 {membership.is_owner ? 'text-yellow-500 hover:scale-110' : ''}"
+							/>
 							{#if !membership.is_owner}
 								<p>{membership.group.owner?.username}</p>
 							{/if}
@@ -177,7 +187,7 @@
 	<InfiniteScrollList {data} {loadMore} step={50}>
 		{#snippet itemSnippet(invitation: Omit<MembershipRead, 'user'>)}
 			<div
-				class="bg-inset flex w-full flex-row items-center justify-between gap-2 rounded-md px-3 py-2.5 shadow-inner shadow-black/30"
+				class="flex w-full flex-row items-center justify-between gap-2 rounded-md bg-inset px-3 py-2.5 shadow-inner shadow-black/30"
 			>
 				<div class="flex min-w-0 flex-1 flex-col gap-1">
 					<h4 class="truncate text-sm font-semibold">{invitation.group.name}</h4>

--- a/frontend/src/lib/components/membershipList.svelte
+++ b/frontend/src/lib/components/membershipList.svelte
@@ -9,15 +9,28 @@
 	import CloseIcon from '~icons/material-symbols/close-rounded';
 	import { page } from '$app/state';
 	import AddIcon from '~icons/material-symbols/add-circle-outline';
+	import PeopleIcon from '~icons/material-symbols/group-outline';
+	import DocumentIcon from '~icons/material-symbols/description-outline';
+	import CrownIcon from '~icons/mdi/crown';
 
 	interface Props {
 		data: Paginated<MembershipRead, 'user'>;
 		sessionUser: UserRead;
 		accepted: boolean;
+		compact?: boolean;
 		onSelect?: (membership: Omit<MembershipRead, 'user'>) => void;
 	}
 
-	let { data, sessionUser, accepted, onSelect }: Props = $props();
+	let { data, sessionUser, accepted, compact = false, onSelect }: Props = $props();
+
+	// Get initials from group name
+	function getInitials(name: string): string {
+		const words = name.trim().split(/\s+/);
+		if (words.length >= 2) {
+			return (words[0][0] + words[1][0]).toUpperCase();
+		}
+		return name.slice(0, 2).toUpperCase();
+	}
 
 	/**
 	 * Load more memberships with pagination.
@@ -97,33 +110,66 @@
 </script>
 
 {#if accepted}
-	<div class="flex flex-row items-center justify-between">
-		<h2 class="w-full text-left text-2xl">{$LL.myGroups()}</h2>
-		<a
-			href="/dashboard/groups/create"
-			class="flex flex-row items-center gap-1 rounded-md bg-inset px-3 py-1 text-sm shadow-inner shadow-black/30 transition-all hover:bg-green-500/20"
-			title="Create new group"
-		>
-			<AddIcon class="h-4 w-4 text-text" />
-			<p class="text-text">New</p>
-		</a>
-	</div>
-	<hr class="border-text/50" />
+	{#if !compact}
+		<div class="flex flex-row items-center justify-between">
+			<h2 class="w-full text-left text-2xl">{$LL.myGroups()}</h2>
+			<a
+				href="/dashboard/groups/create"
+				class="bg-inset flex flex-row items-center gap-1 rounded-md px-3 py-1 text-sm shadow-inner shadow-black/30 transition-all hover:bg-green-500/20"
+				title="Create new group"
+			>
+				<AddIcon class="text-text h-4 w-4" />
+				<p class="text-text">New</p>
+			</a>
+		</div>
+		<hr class="border-text/50" />
+	{/if}
 	<InfiniteScrollList {data} {loadMore} step={2} onSelect={handleSelect}>
 		{#snippet itemSnippet(membership: Omit<MembershipRead, 'user'>)}
-			<div
-				class="group m-1 flex w-full cursor-pointer flex-col gap-1 rounded-md bg-inset px-3 py-2.5 shadow-inner shadow-black/30 transition-all hover:bg-primary"
-				class:bg-primary={membership.group.id === page.params.groupid}
-				class:shadow-inner-sym-[5px]={membership.group.id === page.params.groupid}
-			>
-				<h3 class="truncate text-left text-sm font-semibold">{membership.group.name}</h3>
-				<p class="truncate text-left text-xs opacity-70">
-					{membership.group.owner?.username}
-				</p>
-			</div>
+			{#if compact}
+				<div
+					class="bg-primary/20 hover:bg-primary group m-1 flex w-full cursor-pointer items-center justify-center rounded-md py-2.5 shadow-inner shadow-black/30 transition-all"
+					class:bg-primary={membership.group.id === page.params.groupid}
+					class:shadow-inner-sym-[5px]={membership.group.id === page.params.groupid}
+					title={membership.group.name}
+				>
+					<span class="text-text text-sm font-bold">{getInitials(membership.group.name)}</span>
+				</div>
+			{:else}
+				<div
+					class="bg-inset hover:bg-primary group m-1 flex w-full cursor-pointer flex-col gap-2 rounded-md px-3 py-2.5 shadow-inner shadow-black/30 transition-all"
+					class:bg-primary={membership.group.id === page.params.groupid}
+					class:shadow-inner-sym-[5px]={membership.group.id === page.params.groupid}
+				>
+					<h3 class="truncate text-left text-base font-semibold">{membership.group.name}</h3>
+					<div class="text-text/70 flex items-center gap-3 text-xs">
+						<!-- Member count -->
+						<div class="flex items-center gap-1" title="{membership.group.member_count} member{membership.group.member_count === 1 ? '' : 's'}">
+							<PeopleIcon class="h-4 w-4" />
+							<span>{membership.group.member_count}</span>
+						</div>
+						<!-- Document count -->
+						<div
+							class="flex items-center gap-1"
+							title="{membership.group.document_count} documents"
+						>
+							<DocumentIcon class="h-4 w-4" />
+							<span>{membership.group.document_count}</span>
+						</div>
+						<!-- Owner indicator -->
+
+						<div class="ml-auto flex items-center" title={membership.is_owner ? 'You own this group' : ''}>
+							<CrownIcon class="h-4 w-4 {membership.is_owner ? 'text-yellow-500 hover:scale-110' : ''}" />
+							{#if !membership.is_owner}
+								<p>{membership.group.owner?.username}</p>
+							{/if}
+						</div>
+					</div>
+				</div>
+			{/if}
 		{/snippet}
 	</InfiniteScrollList>
-{:else if data.total > 0}
+{:else if data.total > 0 && !compact}
 	<div class="flex flex-row items-center justify-between">
 		<h2 class="w-full text-left text-xl">{$LL.invitations()}</h2>
 	</div>
@@ -131,7 +177,7 @@
 	<InfiniteScrollList {data} {loadMore} step={50}>
 		{#snippet itemSnippet(invitation: Omit<MembershipRead, 'user'>)}
 			<div
-				class="flex w-full flex-row items-center justify-between gap-2 rounded-md bg-inset px-3 py-2.5 shadow-inner shadow-black/30"
+				class="bg-inset flex w-full flex-row items-center justify-between gap-2 rounded-md px-3 py-2.5 shadow-inner shadow-black/30"
 			>
 				<div class="flex min-w-0 flex-1 flex-col gap-1">
 					<h4 class="truncate text-sm font-semibold">{invitation.group.name}</h4>

--- a/frontend/src/lib/components/sharelinks/shareLinksManager.svelte
+++ b/frontend/src/lib/components/sharelinks/shareLinksManager.svelte
@@ -143,10 +143,6 @@
 <div class="flex flex-col gap-4">
 	<!-- Header -->
 	<div class="flex items-center justify-between">
-		<div>
-			<h2 class="text-lg font-semibold">Share Links</h2>
-			<p class="text-sm text-text/70">Create shareable links with specific permissions</p>
-		</div>
 		{#if !showCreateForm}
 			<button
 				type="button"

--- a/frontend/src/routes/dashboard/+layout.svelte
+++ b/frontend/src/routes/dashboard/+layout.svelte
@@ -60,7 +60,7 @@
 	</div>
 
 	<!-- right column (subpage content, scrollable) -->
-	<div class="h-full flex-1 overflow-y-auto p-4">
+	<div class="h-full flex-1 overflow-y-auto">
 		{@render children?.()}
 	</div>
 </div>

--- a/frontend/src/routes/dashboard/+layout.svelte
+++ b/frontend/src/routes/dashboard/+layout.svelte
@@ -8,7 +8,6 @@
 	let isExpanded = $derived(!page.params.groupid);
 	let isHovering = $state(false);
 
-
 	// Sidebar should be expanded if: isExpanded is true OR user is hovering
 	const shouldShowExpanded = $derived(isExpanded || isHovering);
 
@@ -27,7 +26,7 @@
 	<div
 		role="navigation"
 		aria-label="Groups sidebar"
-		class="no-scrollbar border-text/10 bg-inset flex h-full shrink-0 flex-col gap-2 overflow-y-auto overflow-x-hidden border-r p-2 pb-0 transition-all duration-200"
+		class="no-scrollbar flex h-full shrink-0 flex-col gap-2 overflow-x-hidden overflow-y-auto border-r border-text/10 bg-inset p-2 pb-0 transition-all duration-200"
 		class:w-12={!shouldShowExpanded}
 		class:w-[200px]={shouldShowExpanded}
 		class:sm:w-[200px]={shouldShowExpanded}

--- a/frontend/src/routes/dashboard/+layout.svelte
+++ b/frontend/src/routes/dashboard/+layout.svelte
@@ -4,14 +4,46 @@
 	import { page } from '$app/state';
 
 	let { data, children } = $props();
+
+	let isExpanded = $derived(!page.params.groupid);
+	let isHovering = $state(false);
+
+
+	// Sidebar should be expanded if: isExpanded is true OR user is hovering
+	const shouldShowExpanded = $derived(isExpanded || isHovering);
+
+	function handleGroupSelect(membership: any) {
+		const currentPage = page.url.pathname.split('/').pop();
+		goto(
+			`/dashboard/groups/${membership.group.id}/${(page.params.groupid && currentPage) || 'documents'}`
+		);
+		// Collapse sidebar after selection
+		isExpanded = false;
+	}
 </script>
 
 <div class="flex w-full grow">
 	<!-- left column (groups) -->
-	<div class="flex h-full flex-col gap-2 p-2 pb-0 sm:w-[200px] md:w-[300px] lg:w-[400px]">
+	<div
+		role="navigation"
+		aria-label="Groups sidebar"
+		class="no-scrollbar border-text/10 bg-inset flex h-full shrink-0 flex-col gap-2 overflow-y-auto overflow-x-hidden border-r p-2 pb-0 transition-all duration-200"
+		class:w-12={!shouldShowExpanded}
+		class:w-[200px]={shouldShowExpanded}
+		class:sm:w-[200px]={shouldShowExpanded}
+		class:md:w-[300px]={shouldShowExpanded}
+		class:lg:w-[400px]={shouldShowExpanded}
+		onmouseenter={() => (isHovering = true)}
+		onmouseleave={() => (isHovering = false)}
+	>
 		{#if data.invites}
 			<div class="shrink-0">
-				<MembershipList data={data.invites} sessionUser={data.sessionUser} accepted={false} />
+				<MembershipList
+					data={data.invites}
+					sessionUser={data.sessionUser}
+					accepted={false}
+					compact={!shouldShowExpanded}
+				/>
 			</div>
 		{/if}
 		{#key data}
@@ -20,12 +52,8 @@
 					data={data.memberships}
 					sessionUser={data.sessionUser}
 					accepted={true}
-					onSelect={(membership) => {
-						const currentPage = page.url.pathname.split('/').pop();
-						goto(
-							`/dashboard/groups/${membership.group.id}/${(page.params.groupid && currentPage) || 'documents'}`
-						);
-					}}
+					compact={!shouldShowExpanded}
+					onSelect={handleGroupSelect}
 				/>
 			{/if}
 		{/key}

--- a/frontend/src/routes/dashboard/+layout.ts
+++ b/frontend/src/routes/dashboard/+layout.ts
@@ -2,6 +2,7 @@ import { api } from '$api/client';
 import type { Paginated } from '$api/pagination';
 import type { MembershipRead } from '$api/types';
 import { notification } from '$lib/stores/notificationStore';
+import type { BreadcrumbItem } from '$types/breadcrumb';
 import type { LayoutLoad } from './$types';
 
 // TODO this can probably be a serverlayout in order to prerender the initial list of groups so it gets loaded instantly
@@ -56,6 +57,7 @@ export const load: LayoutLoad = async ({ fetch, parent }) => {
 	return {
 		...(await parent()),
 		memberships: memberships,
-		invites: invites
+		invites: invites,
+		breadcrumbs: [{ label: 'Dashboard' }] satisfies BreadcrumbItem[]
 	};
 };

--- a/frontend/src/routes/dashboard/groups/[groupid]/+layout.svelte
+++ b/frontend/src/routes/dashboard/groups/[groupid]/+layout.svelte
@@ -48,20 +48,6 @@
 		}
 		return currentPath === `${basePath}${itemPath}`;
 	}
-
-	const currentPageTitle = $derived.by(() => {
-		const currentPath = page.url.pathname;
-		const basePath = `/dashboard/groups/${group?.id}`;
-
-		const activeItem = menuItems.find((item) => {
-			if (item.path === '') {
-				return currentPath === basePath;
-			}
-			return currentPath.startsWith(`${basePath}${item.path}`);
-		});
-
-		return activeItem ? activeItem.i18nKey() : '';
-	});
 </script>
 
 {#key page.params.groupid}
@@ -70,33 +56,22 @@
 		in:fly={{ y: -60, duration: 150, delay: 200 }}
 		out:fly={{ y: -60, duration: 200 }}
 	>
-		<!-- Header Section -->
-		<div class="flex flex-col gap-3">
-			<div class="flex flex-row items-center gap-3">
-				<h1 class="text-3xl font-bold">{group?.name}</h1>
-				{#if currentPageTitle && !isActive('')}
-					<span class="text-text/50">/</span>
-					<span class="text-2xl text-text/70">{currentPageTitle}</span>
-				{/if}
-			</div>
-
-			<!-- Navigation Tabs -->
-			<nav class="flex flex-row gap-2 border-b border-text/20">
-				{#each menuItems as item (item.path)}
-					<a
-						href="/dashboard/groups/{group?.id}{item.path}"
-						class="flex flex-row items-center gap-2 border-b-2 px-4 py-2 transition-all {isActive(
-							item.path
-						)
-							? 'border-primary text-primary'
-							: 'border-transparent text-text/70 hover:border-text/30 hover:text-text'}"
-					>
-						<item.icon class="h-5 w-5" />
-						<span>{item.i18nKey()}</span>
-					</a>
-				{/each}
-			</nav>
-		</div>
+		<!-- Navigation Tabs -->
+		<nav class="flex flex-row gap-2 border-b border-text/20">
+			{#each menuItems as item (item.path)}
+				<a
+					href="/dashboard/groups/{group?.id}{item.path}"
+					class="flex flex-row items-center gap-2 border-b-2 px-4 py-2 transition-all {isActive(
+						item.path
+					)
+						? 'border-primary text-primary'
+						: 'border-transparent text-text/70 hover:border-text/30 hover:text-text'}"
+				>
+					<item.icon class="h-5 w-5" />
+					<span>{item.i18nKey()}</span>
+				</a>
+			{/each}
+		</nav>
 
 		<!-- Page Content -->
 		<div class="flex-1 overflow-auto">

--- a/frontend/src/routes/dashboard/groups/[groupid]/+layout.ts
+++ b/frontend/src/routes/dashboard/groups/[groupid]/+layout.ts
@@ -1,6 +1,7 @@
 import { redirect } from '@sveltejs/kit';
 import type { LayoutLoad } from './$types';
 import { notification } from '$lib/stores/notificationStore';
+import type { BreadcrumbItem } from '$types/breadcrumb';
 
 export const load: LayoutLoad = async ({ parent }) => {
 	const data = await parent();
@@ -9,5 +10,12 @@ export const load: LayoutLoad = async ({ parent }) => {
 		notification('error', 'You are not a member of this group.'); // TODO i18n
 		throw redirect(303, '/dashboard');
 	}
-	return { membership, ...data };
+	return {
+		membership,
+		...data,
+		breadcrumbs: [
+			{ label: 'Dashboard', href: '/dashboard' },
+			{ label: membership.group.name }
+		] satisfies BreadcrumbItem[]
+	};
 };

--- a/frontend/src/routes/dashboard/groups/[groupid]/+page.server.ts
+++ b/frontend/src/routes/dashboard/groups/[groupid]/+page.server.ts
@@ -1,0 +1,6 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ url }) => {
+	return redirect(303, url.pathname + '/documents');
+};

--- a/frontend/src/routes/dashboard/groups/[groupid]/documents/+layout.ts
+++ b/frontend/src/routes/dashboard/groups/[groupid]/documents/+layout.ts
@@ -3,6 +3,7 @@ import type { Paginated } from '$api/pagination';
 import type { DocumentRead } from '$api/types';
 import { notification } from '$lib/stores/notificationStore';
 import type { LayoutLoad } from './$types';
+import type { BreadcrumbItem } from '$types/breadcrumb';
 
 export const load: LayoutLoad = async ({ depends, fetch, params, parent }) => {
 	depends('app:documents');
@@ -24,5 +25,16 @@ export const load: LayoutLoad = async ({ depends, fetch, params, parent }) => {
 		return { documents: { data: [], total: 0, offset: 0, limit: 0 }, ...data };
 	}
 	const documents = results.data;
-	return { documents, ...data };
+	return {
+		documents,
+		...data,
+		breadcrumbs: [
+			{ label: 'Dashboard', href: '/dashboard' },
+			{
+				label: data.membership.group.name,
+				href: `/dashboard/groups/${data.membership.group.id}`
+			},
+			{ label: 'Documents' }
+		] satisfies BreadcrumbItem[]
+	};
 };

--- a/frontend/src/routes/dashboard/groups/[groupid]/documents/+page.svelte
+++ b/frontend/src/routes/dashboard/groups/[groupid]/documents/+page.svelte
@@ -25,7 +25,6 @@
 
 <div class="h-screen p-4">
 	<div class="mb-4 flex w-full flex-row items-center justify-between gap-2">
-		<h1 class="text-2xl font-bold">Documents</h1>
 		{#if sessionStore.validatePermissions(['upload_documents'])}
 			<a
 				href="/dashboard/groups/{group.id}/documents/create"

--- a/frontend/src/routes/dashboard/groups/[groupid]/documents/+page.svelte
+++ b/frontend/src/routes/dashboard/groups/[groupid]/documents/+page.svelte
@@ -23,7 +23,7 @@
 	}
 </script>
 
-<div class="h-screen p-4">
+<div class="p-4">
 	<div class="mb-4 flex w-full flex-row items-center justify-between gap-2">
 		{#if sessionStore.validatePermissions(['upload_documents'])}
 			<a

--- a/frontend/src/routes/dashboard/groups/[groupid]/documents/[documentid]/settings/+page.ts
+++ b/frontend/src/routes/dashboard/groups/[groupid]/documents/[documentid]/settings/+page.ts
@@ -2,6 +2,7 @@ import { api } from '$api/client';
 import type { DocumentRead } from '$api/types';
 import { error } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
+import type { BreadcrumbItem } from '$types/breadcrumb';
 
 export const load: PageLoad = async ({ params, parent, fetch }) => {
 	const { membership } = await parent();
@@ -14,6 +15,22 @@ export const load: PageLoad = async ({ params, parent, fetch }) => {
 
 	return {
 		document: documentResult.data,
-		membership
+		membership,
+		breadcrumbs: [
+			{ label: 'Dashboard', href: '/dashboard' },
+			{
+				label: membership.group.name,
+				href: `/dashboard/groups/${membership.group.id}`
+			},
+			{
+				label: 'Documents',
+				href: `/dashboard/groups/${membership.group.id}/documents`
+			},
+			{
+				label: documentResult.data.name,
+				href: `/documents/${documentResult.data.id}`
+			},
+			{ label: 'Settings' }
+		] satisfies BreadcrumbItem[]
 	};
 };

--- a/frontend/src/routes/dashboard/groups/[groupid]/memberships/+page.svelte
+++ b/frontend/src/routes/dashboard/groups/[groupid]/memberships/+page.svelte
@@ -134,7 +134,6 @@
 
 <div class="h-screen p-4">
 	<div class="mb-4 flex w-full flex-row items-center justify-between gap-2">
-		<h1 class="text-2xl font-bold">Member Management</h1>
 		{#if sessionStore.validatePermissions(['add_members'])}
 			<!--INVITE-->
 			<div class="flex flex-row items-end gap-2">
@@ -282,7 +281,9 @@
 </div>
 
 {#snippet permissionItem(perm: Permission)}
-	<p class="p-1 text-left text-text">{$LL.permissions[perm]?.() || perm}</p>
+	<p class="p-1 text-left text-text">
+		{($LL.permissions as Record<string, () => string>)[perm]?.() || perm}
+	</p>
 {/snippet}
 
 {#snippet usernameSnippet(membership: Omit<MembershipRead, 'group'>)}

--- a/frontend/src/routes/dashboard/groups/[groupid]/memberships/+page.svelte
+++ b/frontend/src/routes/dashboard/groups/[groupid]/memberships/+page.svelte
@@ -132,7 +132,7 @@
 	}
 </script>
 
-<div class="h-screen p-4">
+<div class="p-4">
 	<div class="mb-4 flex w-full flex-row items-center justify-between gap-2">
 		{#if sessionStore.validatePermissions(['add_members'])}
 			<!--INVITE-->

--- a/frontend/src/routes/dashboard/groups/[groupid]/memberships/+page.ts
+++ b/frontend/src/routes/dashboard/groups/[groupid]/memberships/+page.ts
@@ -2,8 +2,11 @@ import { api } from '$api/client';
 import type { Paginated } from '$api/pagination';
 import type { MembershipRead } from '$api/types';
 import type { PageLoad } from './$types';
+import type { BreadcrumbItem } from '$types/breadcrumb';
 
-export const load: PageLoad = async ({ fetch, params, url }) => {
+export const load: PageLoad = async ({ fetch, params, url, parent }) => {
+	const { membership } = await parent();
+
 	const result = await api.get<Paginated<MembershipRead>, 'group'>(
 		`/memberships?${url.searchParams}`,
 		{
@@ -22,5 +25,15 @@ export const load: PageLoad = async ({ fetch, params, url }) => {
 		throw new Error(`Failed to load memberships: ${result.error.detail}`);
 	}
 
-	return { memberships: result.data };
+	return {
+		memberships: result.data,
+		breadcrumbs: [
+			{ label: 'Dashboard', href: '/dashboard' },
+			{
+				label: membership.group.name,
+				href: `/dashboard/groups/${membership.group.id}`
+			},
+			{ label: 'Members' }
+		] satisfies BreadcrumbItem[]
+	};
 };

--- a/frontend/src/routes/dashboard/groups/[groupid]/settings/+page.svelte
+++ b/frontend/src/routes/dashboard/groups/[groupid]/settings/+page.svelte
@@ -123,8 +123,6 @@
 </script>
 
 <div class="flex h-full w-full flex-col gap-6 p-6">
-	<h1 class="text-2xl font-bold">Group Settings</h1>
-
 	<!-- Settings Form -->
 	<div class="flex flex-col gap-6">
 		<!-- Group Name -->

--- a/frontend/src/routes/dashboard/groups/[groupid]/settings/+page.ts
+++ b/frontend/src/routes/dashboard/groups/[groupid]/settings/+page.ts
@@ -1,5 +1,6 @@
 import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
+import type { BreadcrumbItem } from '$types/breadcrumb';
 
 export const load: PageLoad = async ({ parent }) => {
 	const { membership, sessionUser } = await parent();
@@ -11,5 +12,16 @@ export const load: PageLoad = async ({ parent }) => {
 		throw redirect(302, `/dashboard/groups/${membership.group.id}/documents`);
 	}
 
-	return { membership, sessionUser };
+	return {
+		membership,
+		sessionUser,
+		breadcrumbs: [
+			{ label: 'Dashboard', href: '/dashboard' },
+			{
+				label: membership.group.name,
+				href: `/dashboard/groups/${membership.group.id}`
+			},
+			{ label: 'Settings' }
+		] satisfies BreadcrumbItem[]
+	};
 };

--- a/frontend/src/routes/dashboard/groups/[groupid]/sharing/+page.ts
+++ b/frontend/src/routes/dashboard/groups/[groupid]/sharing/+page.ts
@@ -3,6 +3,7 @@ import type { Paginated } from '$api/pagination';
 import type { ShareLinkRead } from '$api/types';
 import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
+import type { BreadcrumbItem } from '$types/breadcrumb';
 
 export const load: PageLoad = async ({ parent, params, fetch }) => {
 	const { membership, sessionUser } = await parent();
@@ -26,5 +27,17 @@ export const load: PageLoad = async ({ parent, params, fetch }) => {
 		throw new Error(`Failed to load share links: ${shareLinkResult.error.detail}`);
 	}
 
-	return { membership, sessionUser, shareLinks: shareLinkResult.data };
+	return {
+		membership,
+		sessionUser,
+		shareLinks: shareLinkResult.data,
+		breadcrumbs: [
+			{ label: 'Dashboard', href: '/dashboard' },
+			{
+				label: membership.group.name,
+				href: `/dashboard/groups/${membership.group.id}`
+			},
+			{ label: 'Sharing' }
+		] satisfies BreadcrumbItem[]
+	};
 };

--- a/frontend/src/routes/documents/[documentid]/+page.ts
+++ b/frontend/src/routes/documents/[documentid]/+page.ts
@@ -4,6 +4,7 @@ import { notification } from '$lib/stores/notificationStore';
 import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 import type { Paginated } from '$api/pagination';
+import type { BreadcrumbItem } from '$types/breadcrumb';
 
 export const load: PageLoad = async ({ params, parent, fetch }) => {
 	const { routeMembership: membership } = await parent();
@@ -64,6 +65,19 @@ export const load: PageLoad = async ({ params, parent, fetch }) => {
 		document: documentResult.data,
 		group: membership.group,
 		rootComments: rootComments,
-		documentFile: documentFileResult.data
+		documentFile: documentFileResult.data,
+		breadcrumbs: [
+			{
+				label: membership.group.name,
+				href: `/dashboard/groups/${membership.group.id}`
+			},
+			{
+				label: 'Documents',
+				href: `/dashboard/groups/${membership.group.id}/documents`
+			},
+			{
+				label: documentResult.data.name
+			}
+		] satisfies BreadcrumbItem[]
 	};
 };

--- a/frontend/src/routes/header.svelte
+++ b/frontend/src/routes/header.svelte
@@ -15,6 +15,7 @@
 	import LogoutIcon from '~icons/mdi/exit-run';
 	import { page } from '$app/state';
 	import LL from '$i18n/i18n-svelte';
+	import Breadcrumb from '$lib/components/Breadcrumb.svelte';
 
 	let { user }: { user?: UserPrivate } = $props();
 
@@ -57,18 +58,19 @@
 <div class="h-16.5 w-full"></div>
 <header class="fixed top-0 right-0 left-0 z-9000 h-15.5 w-full bg-background">
 	<div
-		class="center-content dark:shadow-inner-sym-10 mt-1 grid h-full grid-cols-3
-	items-center bg-inset shadow-inner-sym-[10px] shadow-black"
+		class="center-content dark:shadow-inner-sym-10 mt-1 flex h-full
+	items-center justify-between bg-inset shadow-inner-sym-[10px] shadow-black"
 	>
-		<a
-			href="/"
-			class="col-span-1 col-start-1 flex flex-row justify-self-start transition-all hover:pl-0.5"
-		>
-			<img class="w-auto p-2" src={logoSrc} alt="Logo" />
-			<p class="ml-1 self-center text-3xl"></p>
-		</a>
+		<div class="flex items-center gap-4">
+			<a href="/" class="flex flex-row transition-all hover:scale-105">
+				<img class="w-auto p-2" src={logoSrc} alt="Logo" />
+				<p class="ml-1 self-center text-3xl"></p>
+			</a>
 
-		<div class="col-span-1 col-start-3 mr-3 flex flex-row-reverse items-center justify-self-end">
+			<Breadcrumb />
+		</div>
+
+		<div class="mr-3 flex flex-row-reverse items-center">
 			{#if user?.id}
 				<div class="relative z-9500">
 					<button

--- a/frontend/src/types/breadcrumb.ts
+++ b/frontend/src/types/breadcrumb.ts
@@ -1,0 +1,4 @@
+export type BreadcrumbItem = {
+	label: string;
+	href?: string; // undefined = current page (not clickable)
+};


### PR DESCRIPTION
This PR adds a breadcrumb component that shows the current route in he header. Breadcrumbs can be set by returning the breadcrumb config for any `layout.ts` or `page.ts`. Each breadcrumb section can link to different routes based on the config returned from the load function.

There were also some changes and improvements for the dashboard sidebar to be less itnrusive and cleaner.