### PR TITLE
Comment sidebar pass

### DIFF
--- a/frontend/src/lib/actions/preciseHover.ts
+++ b/frontend/src/lib/actions/preciseHover.ts
@@ -1,35 +1,32 @@
-type Params = { onEnter?: () => void; onLeave?: () => void }
+type Params = { onEnter?: () => void; onLeave?: () => void };
 
-export function preciseHover(
-  node: HTMLElement,
-  params: Params
-) {
-  let hovered = false;
+export function preciseHover(node: HTMLElement, params: Params) {
+	let hovered = false;
 
-  function onMove(e: PointerEvent) {
-    const el = document.elementFromPoint(e.clientX, e.clientY);
+	function onMove(e: PointerEvent) {
+		const el = document.elementFromPoint(e.clientX, e.clientY);
 
-    const isTopMost = el === node || node.contains(el);
+		const isTopMost = el === node || node.contains(el);
 
-    if (isTopMost && !hovered) {
-      hovered = true;
-      params.onEnter?.();
-    }
+		if (isTopMost && !hovered) {
+			hovered = true;
+			params.onEnter?.();
+		}
 
-    if (!isTopMost && hovered) {
-      hovered = false;
-      params.onLeave?.();
-    }
-  }
+		if (!isTopMost && hovered) {
+			hovered = false;
+			params.onLeave?.();
+		}
+	}
 
-  window.addEventListener("pointermove", onMove);
+	window.addEventListener('pointermove', onMove);
 
-  return {
-    destroy() {
-      window.removeEventListener("pointermove", onMove);
-    },
-    update(newParams: Params) {
-      params = newParams;
-    }
-  };
+	return {
+		destroy() {
+			window.removeEventListener('pointermove', onMove);
+		},
+		update(newParams: Params) {
+			params = newParams;
+		}
+	};
 }

--- a/frontend/src/lib/actions/preciseHover.ts
+++ b/frontend/src/lib/actions/preciseHover.ts
@@ -1,0 +1,35 @@
+type Params = { onEnter?: () => void; onLeave?: () => void }
+
+export function preciseHover(
+  node: HTMLElement,
+  params: Params
+) {
+  let hovered = false;
+
+  function onMove(e: PointerEvent) {
+    const el = document.elementFromPoint(e.clientX, e.clientY);
+
+    const isTopMost = el === node || node.contains(el);
+
+    if (isTopMost && !hovered) {
+      hovered = true;
+      params.onEnter?.();
+    }
+
+    if (!isTopMost && hovered) {
+      hovered = false;
+      params.onLeave?.();
+    }
+  }
+
+  window.addEventListener("pointermove", onMove);
+
+  return {
+    destroy() {
+      window.removeEventListener("pointermove", onMove);
+    },
+    update(newParams: Params) {
+      params = newParams;
+    }
+  };
+}

--- a/frontend/src/lib/components/pdf/CommentCard.svelte
+++ b/frontend/src/lib/components/pdf/CommentCard.svelte
@@ -278,7 +278,7 @@
 	<!-- Header is rendered by the wrapping CommentCluster component -->
 
 	<!-- Content area -->
-	<div class={isTopLevel ? 'p-3' : ''}>
+	<div class={isTopLevel ? 'p-1.5' : ''}>
 		<!-- Nested header (username + date inline) -->
 		<div class="mb-1 flex items-center justify-between">
 			<div class="flex items-center gap-2">
@@ -343,7 +343,7 @@
 		{/if}
 
 		<!-- Annotation quote (top-level only) -->
-		{#if comment.annotation}
+		{#if comment.annotation && comment.content?.length}
 			<!-- svelte-ignore a11y_click_events_have_key_events -->
 			<!-- svelte-ignore a11y_no_static_element_interactions -->
 			<div
@@ -358,7 +358,7 @@
 			>
 				<p
 					bind:this={quoteRef}
-					class="text-xs text-text/60 italic {isQuoteExpanded ? '' : 'line-clamp-2'}"
+					class="text-xs text-text/60 italic {isQuoteExpanded ? '' : 'line-clamp-1'}"
 				>
 					"{comment.annotation.text}"
 				</p>
@@ -404,8 +404,6 @@
 			<div class={isTopLevel ? 'mb-3' : 'mt-0.5'}>
 				<MarkdownRenderer content={comment.content} class="{sizes.text} {sizes.textMuted}" />
 			</div>
-		{:else if isTopLevel}
-			<p class="mb-3 text-sm text-text/40 italic">No comment text</p>
 		{/if}
 
 		<!-- Reply input -->

--- a/frontend/src/lib/components/pdf/CommentCluster.svelte
+++ b/frontend/src/lib/components/pdf/CommentCluster.svelte
@@ -125,9 +125,9 @@
 		<!-- Expanded card - hover anywhere on card keeps it open -->
 		<div
 			bind:this={clusterRef}
-			class="bg-background ring-primary/30 relative z-50 overflow-hidden rounded-lg shadow-lg shadow-black/20 ring-0 transition-all {firstPinnedComment
-				? 'ring-3'
-				: ''}"
+			class="bg-background ring-3 relative z-50 overflow-hidden rounded shadow-lg shadow-black/20 transition-all {firstPinnedComment
+				? 'ring-primary/70'
+				: 'ring-primary/30'}"
 		>
 			<!-- Cluster header: tabs for multiple comments or single author header -->
 			<div class="border-text/30 w-full border-b p-1.5 pb-0">
@@ -208,7 +208,7 @@
 		>
 			<div
 				class="ring-3 ring-primary/0 {highlightHoveredComment
-					? 'ring-primary/50'
+					? 'ring-primary/70'
 					: ''} flex cursor-pointer flex-row items-center justify-start rounded p-1 transition-all"
 			>
 				<CommentIcon class="text-primary mr-2 h-4 w-4" />

--- a/frontend/src/lib/components/pdf/CommentCluster.svelte
+++ b/frontend/src/lib/components/pdf/CommentCluster.svelte
@@ -128,33 +128,33 @@
 		},
 		onLeave: () => {
 			for (const comment of comments) {
-			documentStore.setCommentHoveredDebounced(comment.id, false);
-		}
+				documentStore.setCommentHoveredDebounced(comment.id, false);
+			}
 		}
 	}}
 	data-comment-badge={activeComment?.id}
 	data-badge-active="true"
-	class="{showCard ? 'w-full' : 'w-fit'}"
+	class={showCard ? 'w-full' : 'w-fit'}
 >
 	{#if showCard}
 		<!-- Expanded card - hover anywhere on card keeps it open -->
 		<div
 			bind:this={clusterRef}
-			class="bg-background ring-3 relative z-50 overflow-hidden rounded shadow-lg shadow-black/20 transition-all {firstPinnedComment
+			class="relative z-50 overflow-hidden rounded bg-background shadow-lg ring-3 shadow-black/20 transition-all {firstPinnedComment
 				? 'ring-primary/70'
 				: 'ring-primary/30'}"
 		>
 			<!-- Cluster header: tabs for multiple comments or single author header -->
-			<div class="border-text/30 w-full border-b p-1.5 pb-0">
-				<div class="border-text/10 pb-0! flex items-center justify-between gap-1.5 border-b">
+			<div class="w-full border-b border-text/30 p-1.5 pb-0">
+				<div class="flex items-center justify-between gap-1.5 border-b border-text/10 pb-0!">
 					<div class="flex flex-wrap items-center gap-1.5">
 						{#each comments as c, idx (c.id)}
 							{@const state = commentStates.get(c.id)}
 							<button
-								class="flex cursor-pointer bg-inset flex-row items-center gap-1.5 rounded-t px-2 pt-1.5 pb-1 text-xs font-medium transition-colors
+								class="flex cursor-pointer flex-row items-center gap-1.5 rounded-t bg-inset px-2 pt-1.5 pb-1 text-xs font-medium transition-colors
 							{activeComment === c
 									? 'text-text shadow-inner shadow-text/40'
-									: 'text-text/50 hover:bg-text/5 hover:text-text/70 hover:animate-pulse'}"
+									: 'text-text/50 hover:animate-pulse hover:bg-text/5 hover:text-text/70'}"
 								onclick={(e) => {
 									e.stopPropagation();
 									if (activeComment === c && state) {
@@ -184,9 +184,9 @@
 							>
 								<p>{c.user?.username?.slice(0, 10) ?? `Comment ${idx + 1}`}</p>
 								{#if state?.isPinned}
-									<PinIcon class="text-text h-4 w-4 transition-colors hover:text-red-400" />
+									<PinIcon class="h-4 w-4 text-text transition-colors hover:text-red-400" />
 								{:else if c.id === activeComment.id}
-									<PinOffIcon class="hover:text-text h-4 w-4" />
+									<PinOffIcon class="h-4 w-4 hover:text-text" />
 								{/if}
 							</button>
 						{/each}
@@ -225,11 +225,11 @@
 					? 'ring-primary/70'
 					: ''} flex cursor-pointer flex-row items-center justify-start rounded p-1 transition-all"
 			>
-				<CommentIcon class="text-primary mr-2 h-4 w-4" />
+				<CommentIcon class="mr-2 h-4 w-4 text-primary" />
 				<p>{previewAuthor?.username ?? 'Unknown'}</p>
 				{#if authorsInCluster.length > 1}
 					<span
-						class="bg-primary/10 text-primary ml-2 rounded-full px-2 py-0.5 text-xs font-medium"
+						class="ml-2 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
 					>
 						+ {authorsInCluster.length - 1}
 					</span>

--- a/frontend/src/lib/components/pdf/CommentCluster.svelte
+++ b/frontend/src/lib/components/pdf/CommentCluster.svelte
@@ -6,6 +6,8 @@
 	import CommentIcon from '~icons/material-symbols/comment-outline';
 	import PinIcon from '~icons/material-symbols/push-pin';
 	import PinOffIcon from '~icons/material-symbols/push-pin-outline';
+	import type { UserRead } from '$api/types';
+	import { preciseHover } from '$lib/actions/preciseHover';
 
 	interface Props {
 		comments: TypedComment[];
@@ -16,12 +18,22 @@
 
 	let { comments, yPosition, scrollTop, onHeightChange }: Props = $props();
 
+	let authorsInCluster = $derived.by(() => {
+		const authorSet = new SvelteMap<number, UserRead>();
+		for (const comment of comments) {
+			if (comment.user?.id) {
+				authorSet.set(comment.user.id, comment.user);
+			}
+		}
+		return Array.from(authorSet.values());
+	});
+
 	let commentStates = $derived.by(
 		() => new SvelteMap(comments.map((c) => [c.id, documentStore.comments.getState(c.id)]))
 	);
 
 	// Track which comment is selected in this group (defaults to first)
-	// eslint-disable-next-line svelte/prefer-writable-derived
+
 	let selectedTabId = $state<number | null>(null);
 
 	let hoveredTabId: number | null = $state(null);
@@ -54,23 +66,21 @@
 			comments[0]
 	);
 
-	$effect(() => {
-		selectedTabId = activeComment.id;
-	});
+	// $effect(() => {
+	// 	selectedTabId = activeComment.id;
+	// });
 
 	let activeCommentState = $derived.by(() => commentStates.get(activeComment.id));
 
 	// Show expanded card when badge is hovered, highlight is hovered, comment is pinned, or input is active
 	let showCard = $derived(
 		hoveredTabCommentState ||
-			highlightHoveredComment ||
 			firstPinnedComment ||
 			firstEditingComment ||
 			firstReplyingComment ||
 			firstCommentHovered
 	);
 
-	let commentCount = $derived(comments.length);
 	let clusterRef: HTMLElement | null = $state(null);
 
 	// Measure and report cluster height when it changes
@@ -95,107 +105,121 @@
 	});
 </script>
 
-{#if showCard}
-	<!-- Expanded card - hover anywhere on card keeps it open -->
-	<!-- svelte-ignore a11y_no_static_element_interactions -->
-	<div
-		bind:this={clusterRef}
-		class="relative z-50 overflow-hidden rounded-lg bg-background shadow-lg ring-0 shadow-black/20 ring-primary/30 transition-all {firstPinnedComment
-			? 'ring-3'
-			: ''}"
-		tabindex="-1"
-		data-comment-badge={activeComment?.id}
-		data-badge-active="true"
-		onmouseleave={() => {
-			documentStore.setCommentHoveredDebounced(activeComment.id, false);
-		}}
-		onmouseenter={() => {
+<div
+	tabindex="-1"
+	use:preciseHover={{
+		onEnter: () => {
 			documentStore.setCommentHoveredDebounced(activeComment.id, true);
-		}}
-	>
-		<!-- Cluster header: tabs for multiple comments or single author header -->
-		<div class="w-full border-b border-text/30 p-1.5 pb-0">
-			<div class="flex items-center justify-between gap-1.5 border-b border-text/10 pb-0!">
-				<div class="flex flex-wrap items-center gap-1.5">
-					{#each comments as c, idx (c.id)}
-						{@const state = commentStates.get(c.id)}
-						<button
-							class="flex cursor-pointer flex-row items-center gap-1.5 rounded-t px-2 py-1.5 text-xs font-medium transition-colors
+		},
+		onLeave: () => {
+			for (const comment of comments) {
+			documentStore.setCommentHoveredDebounced(comment.id, false);
+		}
+		}
+	}}
+	data-comment-badge={activeComment?.id}
+	data-badge-active="true"
+>
+	{#if showCard}
+		<!-- Expanded card - hover anywhere on card keeps it open -->
+		<div
+			bind:this={clusterRef}
+			class="bg-background ring-primary/30 relative z-50 overflow-hidden rounded-lg shadow-lg shadow-black/20 ring-0 transition-all {firstPinnedComment
+				? 'ring-3'
+				: ''}"
+		>
+			<!-- Cluster header: tabs for multiple comments or single author header -->
+			<div class="border-text/30 w-full border-b p-1.5 pb-0">
+				<div class="border-text/10 pb-0! flex items-center justify-between gap-1.5 border-b">
+					<div class="flex flex-wrap items-center gap-1.5">
+						{#each comments as c, idx (c.id)}
+							{@const state = commentStates.get(c.id)}
+							<button
+								class="flex cursor-pointer flex-row items-center gap-1.5 rounded-t px-2 py-1.5 text-xs font-medium transition-colors
 							{activeComment === c
-								? 'bg-inset text-text'
-								: 'text-text/50 hover:animate-pulse hover:bg-text/5 hover:text-text/70'}"
-							onclick={(e) => {
-								e.stopPropagation();
-								if (activeComment === c && state) {
-									state.isPinned = !state.isPinned;
-									return;
-								}
-								if (state) {
-									state.isCommentHovered = true;
-									// state.isPinned = activeCommentState?.isPinned;
-								}
-								if (activeCommentState) {
-									// activeCommentState.isPinned = false;
-									activeCommentState.isCommentHovered = false;
-								}
+									? 'bg-inset text-text'
+									: 'text-text/50 hover:bg-text/5 hover:text-text/70 hover:animate-pulse'}"
+								onclick={(e) => {
+									e.stopPropagation();
+									if (activeComment === c && state) {
+										state.isPinned = !state.isPinned;
+										return;
+									}
+									if (state) {
+										state.isCommentHovered = true;
+										// state.isPinned = activeCommentState?.isPinned;
+									}
+									if (activeCommentState) {
+										// activeCommentState.isPinned = false;
+										activeCommentState.isCommentHovered = false;
+									}
 
-								selectedTabId = c.id;
-							}}
-							onmouseenter={() => {
-								hoveredTabId = c.id;
-								if (state) state.isCommentHovered = true;
-							}}
-							onmouseleave={() => {
-								hoveredTabId = null;
-								if (activeComment === c) return;
-								if (state) state.isCommentHovered = false;
-							}}
-						>
-							<p>{c.user?.username?.slice(0, 10) ?? `Comment ${idx + 1}`}</p>
-							{#if state?.isPinned}
-								<PinIcon class="h-4 w-4 text-text transition-colors hover:text-red-400" />
-							{:else if c.id === activeComment.id}
-								<PinOffIcon class="h-4 w-4 hover:text-text" />
-							{/if}
-						</button>
-					{/each}
+									selectedTabId = c.id;
+								}}
+								onmouseenter={() => {
+									hoveredTabId = c.id;
+									if (state) state.isCommentHovered = true;
+								}}
+								onmouseleave={() => {
+									hoveredTabId = null;
+									if (activeComment === c) return;
+									if (state) state.isCommentHovered = false;
+								}}
+							>
+								<p>{c.user?.username?.slice(0, 10) ?? `Comment ${idx + 1}`}</p>
+								{#if state?.isPinned}
+									<PinIcon class="text-text h-4 w-4 transition-colors hover:text-red-400" />
+								{:else if c.id === activeComment.id}
+									<PinOffIcon class="hover:text-text h-4 w-4" />
+								{/if}
+							</button>
+						{/each}
+					</div>
 				</div>
 			</div>
-		</div>
-		{#if activeComment}
-			<CommentCard comment={activeComment} />
+			{#if activeComment}
+				<CommentCard comment={activeComment} />
 
-			{#if hoveredTabCommentState || firstCommentHovered || highlightHoveredComment}
-				<!-- Connection line for this card -->
+				{#if hoveredTabCommentState || firstCommentHovered || highlightHoveredComment}
+					<!-- Connection line for this card -->
 
-				{#key hoveredTabCommentState?.id ?? activeCommentState?.id}
-					<ConnectionLine
-						commentState={hoveredTabCommentState ?? activeCommentState}
-						{yPosition}
-						{scrollTop}
-					/>
-				{/key}
+					{#key hoveredTabCommentState?.id ?? activeCommentState?.id}
+						<ConnectionLine
+							commentState={hoveredTabCommentState ?? activeCommentState}
+							{yPosition}
+							{scrollTop}
+						/>
+					{/key}
+				{/if}
 			{/if}
-		{/if}
-	</div>
-{:else}
-	<!-- Compact badge - only hover on badge itself triggers expansion -->
-	<button
-		bind:this={clusterRef}
-		class="relative z-10 inline-block"
-		data-comment-badge={activeComment?.id}
-		onmouseenter={() => {
-			documentStore.setCommentHoveredDebounced(activeComment.id, true);
-		}}
-	>
+		</div>
+	{:else}
+		{@const badgePreviewUser = highlightHoveredComment?.user ?? authorsInCluster[0]}
+		<!-- Compact badge - only hover on badge itself triggers expansion -->
 		<div
-			class="flex h-8 w-8 cursor-pointer items-center justify-center rounded bg-inset shadow-md ring-3 shadow-black/20 ring-primary/70 drop-shadow-xs"
+			role="combobox"
+			aria-controls="false"
+			aria-expanded="false"
+			tabindex={activeComment.id}
+			bind:this={clusterRef}
+			class="relative z-10 inline-block"
+			data-comment-badge={activeComment?.id}
 		>
-			{#if commentCount > 1}
-				<span class="font-bold text-text">{commentCount}</span>
-			{:else}
-				<CommentIcon class="h-4 w-4 text-text" />
-			{/if}
+			<div
+				class="{highlightHoveredComment
+					? 'ring-3'
+					: ''} ring-primary/50 flex cursor-pointer flex-row items-center justify-start rounded p-1"
+			>
+				<CommentIcon class="text-primary mr-2 h-4 w-4" />
+				<p>{badgePreviewUser?.username ?? 'Unknown'}</p>
+				{#if authorsInCluster.length > 1}
+					<span
+						class="bg-primary/10 text-primary ml-2 rounded-full px-2 py-0.5 text-xs font-medium"
+					>
+						+ {authorsInCluster.length - 1}
+					</span>
+				{/if}
+			</div>
 		</div>
-	</button>
-{/if}
+	{/if}
+</div>

--- a/frontend/src/lib/components/pdf/CommentCluster.svelte
+++ b/frontend/src/lib/components/pdf/CommentCluster.svelte
@@ -119,6 +119,7 @@
 	}}
 	data-comment-badge={activeComment?.id}
 	data-badge-active="true"
+	class="{showCard ? 'w-full' : 'w-fit'}"
 >
 	{#if showCard}
 		<!-- Expanded card - hover anywhere on card keeps it open -->
@@ -135,9 +136,9 @@
 						{#each comments as c, idx (c.id)}
 							{@const state = commentStates.get(c.id)}
 							<button
-								class="flex cursor-pointer flex-row items-center gap-1.5 rounded-t px-2 py-1.5 text-xs font-medium transition-colors
+								class="flex cursor-pointer bg-inset flex-row items-center gap-1.5 rounded-t px-2 pt-1.5 pb-1 text-xs font-medium transition-colors
 							{activeComment === c
-									? 'bg-inset text-text'
+									? 'text-text shadow-inner shadow-text/40'
 									: 'text-text/50 hover:bg-text/5 hover:text-text/70 hover:animate-pulse'}"
 								onclick={(e) => {
 									e.stopPropagation();
@@ -202,13 +203,13 @@
 			aria-expanded="false"
 			tabindex={activeComment.id}
 			bind:this={clusterRef}
-			class="relative z-10 inline-block"
+			class="relative z-10 w-fit"
 			data-comment-badge={activeComment?.id}
 		>
 			<div
-				class="{highlightHoveredComment
-					? 'ring-3'
-					: ''} ring-primary/50 flex cursor-pointer flex-row items-center justify-start rounded p-1"
+				class="ring-3 ring-primary/0 {highlightHoveredComment
+					? 'ring-primary/50'
+					: ''} flex cursor-pointer flex-row items-center justify-start rounded p-1 transition-all"
 			>
 				<CommentIcon class="text-primary mr-2 h-4 w-4" />
 				<p>{badgePreviewUser?.username ?? 'Unknown'}</p>

--- a/frontend/src/lib/components/pdf/CommentSidebar.svelte
+++ b/frontend/src/lib/components/pdf/CommentSidebar.svelte
@@ -143,9 +143,17 @@
 	let repositionedClusters = $derived.by((): CommentClusterData[] => {
 		const GAP_PX = 8; // Gap between clusters
 
-		// Work on a shallow clone of baseClusters to avoid mutating the original
-		// (Svelte needs new object references to ensure the template updates)
-		const adjusted = baseClusters;
+		// Depend on clusterHeights to recalculate when heights change
+		void clusterHeights;
+
+		// Deep clone baseClusters to avoid mutating the original
+		// Each cluster needs its own copy of highlightPosition
+		const adjusted = baseClusters.map((cluster) =>
+			cluster.map((comment) => ({
+				...comment,
+				highlightPosition: { ...comment.highlightPosition }
+			}))
+		);
 
 		// Iteratively adjust positions from top to bottom using the clones
 		for (let i = 0; i < adjusted.length; i++) {

--- a/frontend/src/lib/components/pdf/CommentSidebar.svelte
+++ b/frontend/src/lib/components/pdf/CommentSidebar.svelte
@@ -2,7 +2,7 @@
 	import { documentStore, type TypedComment } from '$lib/runes/document.svelte.js';
 	import CommentCluster from './CommentCluster.svelte';
 	import { onMount } from 'svelte';
-	import { CLUSTER_THRESHOLD_PX, BADGE_HEIGHT_PX } from './constants';
+	import { BADGE_HEIGHT_PX } from './constants';
 	import type { Annotation } from '$types/pdf';
 	import { SvelteMap } from 'svelte/reactivity';
 
@@ -17,7 +17,7 @@
 
 	// Calculate the Y position of each comment relative to the sidebar's scroll position
 	// Returns the CENTER Y position of the first highlight box
-	const getCommentYPosition = (comment: TypedComment): number | null => {
+	const getCommentPosition = (comment: TypedComment): { x: number; y: number } | null => {
 		if (!viewerContainer || !comment.annotation) return null;
 
 		const firstBox = comment.annotation.boundingBoxes[0];
@@ -51,17 +51,16 @@
 		const yRelativeToContainer = annotationCenterInViewport - containerRect.top;
 
 		// Offset by half badge height to center the badge
-		return yRelativeToContainer - BADGE_HEIGHT_PX / 2;
+		return {
+			x: firstBox.x * textLayerRect.width,
+			y: yRelativeToContainer - BADGE_HEIGHT_PX / 2
+		};
 	};
 
 	// Group comments by Y position proximity (clustering)
-	interface CommentClusterData {
-		comments: TypedComment[];
-		yPosition: number;
-	}
-
-	// Update tick triggered by text layer resizes
-	let clustersUpdateTick = $state(0);
+	type CommentClusterData = (TypedComment & {
+		highlightPosition: { x: number; y: number };
+	})[];
 
 	// Track actual rendered heights of clusters (key is comment IDs joined)
 	let clusterHeights = new SvelteMap<string, number>();
@@ -71,86 +70,102 @@
 		return comments.some((c) => {
 			const state = documentStore.comments.getState(c.id);
 			return (
-				state?.isCommentHovered || state?.isHighlightHovered || state?.isPinned || state?.isEditing
+				state?.isCommentHovered ||
+				state?.isHighlightHovered ||
+				state?.isPinned ||
+				state?.isEditing ||
+				state?.isReplying
 			);
 		});
 	};
 
 	let baseClusters = $derived.by((): CommentClusterData[] => {
 		// Depend on the update tick (triggered by ResizeObserver)
-		void clustersUpdateTick;
 		void scrollTop;
 
-		const positioned = documentStore.comments.topLevelComments
+		const commentPositionMap = documentStore.comments.topLevelComments
 			.map((comment) => ({
 				comment,
-				y: getCommentYPosition(comment)
+				highlightPosition: getCommentPosition(comment)
 			}))
 			.filter(
-				(item): item is { comment: TypedComment & { annotation: Annotation }; y: number } =>
-					!!item.y
+				(
+					item
+				): item is {
+					comment: TypedComment & { annotation: Annotation };
+					highlightPosition: { x: number; y: number };
+				} => !!item.highlightPosition
 			)
-			.sort((a, b) => a.y - b.y);
+			.sort((a, b) => {
+				return a.highlightPosition.y - b.highlightPosition.y;
+			});
 
-		if (positioned.length === 0) return [];
+		if (commentPositionMap.length === 0) return [];
 
 		const result: CommentClusterData[] = [];
-		let currentCluster: CommentClusterData = {
-			comments: [positioned[0].comment],
-			yPosition: positioned[0].y
-		};
+		let currentCluster: CommentClusterData = [
+			{
+				...commentPositionMap[0].comment,
+				highlightPosition: commentPositionMap[0].highlightPosition
+			}
+		];
 
-		for (let i = 1; i < positioned.length; i++) {
-			const item = positioned[i];
-			const lastClusterY = currentCluster.yPosition;
-
-			if (item.y - lastClusterY <= CLUSTER_THRESHOLD_PX) {
+		for (let i = 1; i < commentPositionMap.length; i++) {
+			const item = commentPositionMap[i];
+			const lastClusterY = currentCluster[0].highlightPosition.y;
+			if (item.highlightPosition.y - lastClusterY <= BADGE_HEIGHT_PX) {
 				// Merge into current cluster
-				currentCluster.comments.push(item.comment);
+				currentCluster.push({
+					...item.comment,
+					highlightPosition: item.highlightPosition
+				});
+				currentCluster = currentCluster.sort((a, b) => {
+					return a.id - b.id;
+				});
 			} else {
 				// Start a new cluster
 				result.push(currentCluster);
-				currentCluster = {
-					comments: [item.comment],
-					yPosition: item.y
-				};
+				currentCluster = [
+					{
+						...item.comment,
+						highlightPosition: item.highlightPosition
+					}
+				];
 			}
 		}
 
 		// Don't forget the last cluster
 		result.push(currentCluster);
-
 		return result;
 	});
 
 	// Adjust cluster positions to prevent overlaps with expanded cards
-	let clusters = $derived.by((): CommentClusterData[] => {
+	let repositionedClusters = $derived.by((): CommentClusterData[] => {
 		const GAP_PX = 8; // Gap between clusters
 
 		// Work on a shallow clone of baseClusters to avoid mutating the original
 		// (Svelte needs new object references to ensure the template updates)
-		const adjusted = baseClusters.map((c) => ({ ...c, comments: c.comments.slice() }));
+		const adjusted = baseClusters;
 
 		// Iteratively adjust positions from top to bottom using the clones
 		for (let i = 0; i < adjusted.length; i++) {
 			const current = adjusted[i];
-			const currentKey = current.comments.map((c) => c.id).join('-');
 
 			// Get the actual rendered height, or use badge height as fallback
-			const currentIsExpanded = isClusterExpanded(current.comments);
+			const currentIsExpanded = isClusterExpanded(current);
 			const currentHeight = currentIsExpanded
-				? clusterHeights.get(currentKey) || BADGE_HEIGHT_PX
+				? clusterHeights.get(current[0].id.toString()) || BADGE_HEIGHT_PX
 				: BADGE_HEIGHT_PX;
 
-			const currentBottom = current.yPosition + currentHeight;
+			const currentBottom = current[0].highlightPosition.y + currentHeight;
 
 			// Check all clusters below and push them down if they overlap
 			for (let j = i + 1; j < adjusted.length; j++) {
 				const below = adjusted[j];
 
 				// If current cluster's bottom overlaps with the cluster below, push it down
-				if (currentBottom + GAP_PX > below.yPosition) {
-					below.yPosition = currentBottom + GAP_PX;
+				if (currentBottom + GAP_PX > below[0].highlightPosition.y) {
+					below[0].highlightPosition.y = currentBottom + GAP_PX;
 				}
 			}
 		}
@@ -163,58 +178,27 @@
 		if (!viewerContainer) return;
 
 		documentStore.commentSidebarRef = containerElement;
-
-		// Use ResizeObserver to detect when PDF.js finishes scaling text layers
-		// Wait 2 RAF to match AnnotationLayer timing
-		const resizeObserver = new ResizeObserver(() => {
-			clustersUpdateTick++;
-		});
-
-		// Observe all existing text layers
-		const textLayers = viewerContainer.querySelectorAll('.textLayer');
-		textLayers.forEach((layer) => resizeObserver.observe(layer as HTMLElement));
-
-		// MutationObserver to detect new pages/text layers being added
-		const mutationObserver = new MutationObserver(() => {
-			const newTextLayers = viewerContainer.querySelectorAll('.textLayer');
-			newTextLayers.forEach((layer) => {
-				// ResizeObserver is safe to call multiple times on same element
-				resizeObserver.observe(layer as HTMLElement);
-			});
-		});
-
-		mutationObserver.observe(viewerContainer, {
-			childList: true,
-			subtree: true
-		});
-
-		// Initial calculation
-		clustersUpdateTick++;
-
-		return () => {
-			resizeObserver.disconnect();
-			mutationObserver.disconnect();
-		};
 	});
 </script>
 
 <div class="relative h-full" bind:this={containerElement}>
-	{#each clusters as cluster (cluster.comments.map((c) => c.id).join('-'))}
-		{@const clusterKey = cluster.comments.map((c) => c.id).join('-')}
-		<div class="absolute right-3 left-3" style="top: {cluster.yPosition}px;">
-			<CommentCluster
-				comments={cluster.comments}
-				yPosition={cluster.yPosition}
-				{scrollTop}
-				onHeightChange={(height: number) => {
-					clusterHeights.set(clusterKey, height);
-					clusterHeights = clusterHeights; // trigger reactivity
-				}}
-			/>
-		</div>
-	{/each}
+	{#key repositionedClusters.length}
+		{#each repositionedClusters as cluster, idx (idx)}
+			<div class="absolute right-3 left-3" style="top: {cluster[0].highlightPosition.y}px;">
+				<CommentCluster
+					comments={cluster}
+					yPosition={cluster[0].highlightPosition.y}
+					{scrollTop}
+					onHeightChange={(height: number) => {
+						clusterHeights.set(cluster[0].id.toString(), height);
+						clusterHeights = clusterHeights; // trigger reactivity
+					}}
+				/>
+			</div>
+		{/each}
+	{/key}
 
-	{#if !clusters.length}
+	{#if !repositionedClusters.length}
 		<div class="flex h-full items-center justify-center p-4">
 			<p class="text-center text-sm text-text/40">Select text in the PDF to add a comment</p>
 		</div>

--- a/frontend/src/lib/components/pdf/CommentSidebar.svelte
+++ b/frontend/src/lib/components/pdf/CommentSidebar.svelte
@@ -191,7 +191,6 @@
 					{scrollTop}
 					onHeightChange={(height: number) => {
 						clusterHeights.set(cluster[0].id.toString(), height);
-						clusterHeights = clusterHeights; // trigger reactivity
 					}}
 				/>
 			</div>

--- a/frontend/src/lib/components/pdf/ConnectionLine.svelte
+++ b/frontend/src/lib/components/pdf/ConnectionLine.svelte
@@ -8,6 +8,7 @@
 		scrollTop?: number;
 	}
 
+	// TODO: use position data from cluster instead of recalculating
 	let { commentState, opacity = 1, yPosition, scrollTop }: Props = $props();
 
 	interface LineCoordinates {
@@ -36,15 +37,12 @@
 		const clusterLeft = sidebarRect.left + LEFT_PADDING;
 		const clusterTop = sidebarRect.top + yPosition;
 
-		console.log(`num els: ${highlightEls.length}`);
-
 		// Get the rightmost edge from all highlights for horizontal positioning
 		let maxRight = -Infinity;
 		let minTop = +Infinity;
 		let heightTotal = 0;
 		highlightEls.forEach((el) => {
 			const rect = el.getBoundingClientRect();
-			console.log(el.dataset);
 			heightTotal += rect.height;
 			maxRight = Math.max(maxRight, rect.right);
 			minTop = Math.min(minTop, rect.top);

--- a/frontend/src/lib/runes/document.svelte.ts
+++ b/frontend/src/lib/runes/document.svelte.ts
@@ -153,7 +153,9 @@ const createDocumentStore = () => {
 					(comment) => !!comment.tags && comment.tags.some((t) => includedTagIds.includes(t.id))
 				);
 			}
-		} else if (excludedFilters.length > 0) {
+		} 
+		
+		if (excludedFilters.length > 0) {
 			// Apply exclude filters when no include filters present.
 			if (excludedAuthorIds.length > 0) {
 				filteredArray = filteredArray.filter(

--- a/frontend/src/lib/runes/document.svelte.ts
+++ b/frontend/src/lib/runes/document.svelte.ts
@@ -153,8 +153,8 @@ const createDocumentStore = () => {
 					(comment) => !!comment.tags && comment.tags.some((t) => includedTagIds.includes(t.id))
 				);
 			}
-		} 
-		
+		}
+
 		if (excludedFilters.length > 0) {
 			// Apply exclude filters when no include filters present.
 			if (excludedAuthorIds.length > 0) {

--- a/frontend/src/lib/runes/document.svelte.ts
+++ b/frontend/src/lib/runes/document.svelte.ts
@@ -554,7 +554,7 @@ const createDocumentStore = () => {
 				if (currentTimeouts) {
 					hoverTimeouts.set(commentId, { ...currentTimeouts, highlight: undefined });
 				}
-			}, 300) as unknown as number;
+			}, 50) as unknown as number;
 
 			hoverTimeouts.set(commentId, { ...timeouts, highlight: timeoutId });
 		}
@@ -587,7 +587,7 @@ const createDocumentStore = () => {
 				if (currentTimeouts) {
 					hoverTimeouts.set(commentId, { ...currentTimeouts, comment: undefined });
 				}
-			}, 100) as unknown as number;
+			}, 50) as unknown as number;
 
 			hoverTimeouts.set(commentId, { ...timeouts, comment: timeoutId });
 		}


### PR DESCRIPTION
This PR includes a major fix for the comment sidebar clustering logic. Previously when creating comments all clusters below the created one had their elements orphaned and were stuck in screenspace while the highlights and orphaned elements were also not interactable anymore.

I also slightly compacted the comment visually and adjusted clusters to not expand when the comment is hovered and instead show a border around the badge. Badges have also been adjusted to show the name of one of the authors in the cluster (either chronologically first or comment with highest reply count) instead of just the number. The abdge will also show if there are multiple authors within a cluster.

I also improved the reliability of hover states to be 100% reliable instead of having edge cases where frame skips resulted in comments being left in hover state while not actually hovered.